### PR TITLE
Fix/21 sk breaking changes fix

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/dotnet
+{
+	"name": "C# (.NET)",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/dotnet:1-7.0-bullseye",
+	"features": {
+		"ghcr.io/devcontainers/features/dotnet:2": {}
+	}
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [5000, 5001],
+	// "portsAttributes": {
+	//		"5001": {
+	//			"protocol": "https"
+	//		}
+	// }
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "dotnet restore",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -403,3 +403,4 @@ notebooks/dotnet/config/settings.json
 notebooks/python/*/OAI_CONFIG_LIST
 notebooks/python/*/coding
 
+config/settings.json

--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -187,7 +187,7 @@ Ensure that the `OpenAiConfigs` section in `config/settings.json` is correctly c
           "BaseUrl": "<your Azure OpenAI API base here>",
           "ModelId": "<deployment id for the model>",
           "ModelType": "<must be completions or embeddings>",
-          "ServiceId": ""
+          "ServiceId": "<must be a unique string;e.g. az-gpt-4>"
       }
   ]
   ```
@@ -275,7 +275,7 @@ These resources should provide a comprehensive guide to installing VS Code and s
 #### 3.4. **ChatGPT Plugin Quickstart using Python and FastAPI**:
 - **[ChatGPT Plugin Quickstart using Python and FastAPI](https://github.com/Azure-Samples/openai-plugin-fastapi)**: This repository contains a sample ChatGPT Plugin using GitHub Codespaces, VS Code (locally), and Azure.
 
-For this example, plese follow the [Run Locally](https://github.com/Azure-Samples/openai-plugin-fastapi#run-locally) instructions.
+For this example, please follow the [Run Locally](https://github.com/Azure-Samples/openai-plugin-fastapi#run-locally) instructions.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -63,20 +63,12 @@ Click this button to deploy an `Azure Cognitive Search` service:
 - In the left pane, select **Keys** to access the admin and query keys.
 - Copy the **Admin key** or **Query key** as required for your application.
 - Setup Config:
-  - To set up configuration values using `settings.json`:
+  - To set up configuration values using `config/settings.json`:
     ```json
-    "AIConfiguration": {
-      "AzureSearch": {
+    "AzureSearchConfig": {
         "Endpoint": "<YOUR_ENDPOINT>",
         "AdminKey": "<YOUR_ADMIN_KEY>"
-      }
     }
-    ```
-    
-  - Or using .NET user secrets
-    ```cmd
-    dotnet user-secrets set "AIConfiguration:AzureSearch:Endpoint" "<YOUR_ENDPOINT>"
-    dotnet user-secrets set "AIConfiguration:AzureSearch:AdminKey" "<YOUR_ADMIN_KEY>"
     ```
 
 
@@ -149,40 +141,56 @@ Click this button to deploy an `Azure OpenAI` service:
 [![Deploy Azure OpenAI Service](https://aka.ms/deploytoazurebutton)](https://aka.ms/byoc-deploy-openai)
 
 #### Post-Deployment:
+
+After deployment, you will need to configure the service to use the desired model. To do so, follow these steps:
+
+- Create an **Azure OpenAI Service** resource in the Azure Portal. 
+- After deploying, open the **Azure OpenAI Service** resource within the Azure Portal.
+- Open the **Azure OpenAI Service Portal** at [https://oai.azure.com/portal](https://oai.azure.com/portal). 
+- Click on **Deployments** in the left sidebar.
+- Click on **Create New Deployment**.
+- Select a completion model and an embeddings model.
+  - For the completion model, select a model greater or equal to `gpt-35-turbo-16k`, ideally `gpt-4`.
+  - For the embeddings model, select `text-embedding-ada-002`.
+  - If possible, keep the deployment name the same as the model name. You will use this in `ModelId` below.
+- Now to get your **Keys and Endpoint** click on the cog icon in the top right corner of the portal.
+- Click on **Resource** on the opt nav bar.
+- Now the **Keys and Endpoint** should be available.
+
+
+
 - After deploying, open the **Azure OpenAI Service** resource within the Azure Portal.
 - Click on **Keys and Endpoint** on the left sidebar.
 - Retrieve the desired **API key** for integration with your application.
-- Setup Config:
-  - To set up configuration values using `settings.json`:
-    ```json
-    "AIConfiguration": {
-      "GenerativeAI": {
-        "DefaultProviders": {
-          "CompletionService": "Azure",
-          "ChatService": "Azure",
-          "EmbeddingService": "Azure"
-        },
-        "Azure": {
-          "Endpoint": "https://YOUR-SERVICE.azure.com/",
-          "CompletionModelName": "YOUR gpt-3.5-turbo-instruct DEPLOYMENT NAME",
-          "ChatModelName": "YOUR gpt-4 DEPLOYMENT NAME",
-          "EmbeddingModelName": "YOUR text-embedding-ada-002 DEPLOYMENT NAME"
-        }
-      }
-    }
-    ```
-    
-  - Or using .NET user secrets
-    ```cmd
-      dotnet user-secrets set "AIConfiguration:GenerativeAI:DefaultProviders:CompletionService" "Azure"
-      dotnet user-secrets set "AIConfiguration:GenerativeAI:DefaultProviders:ChatService" "Azure"
-      dotnet user-secrets set "AIConfiguration:GenerativeAI:DefaultProviders:EmbeddingService" "Azure"
-      dotnet user-secrets set "AIConfiguration:GenerativeAI:Azure:Endpoint" "https://YOUR-SERVICE.azure.com/"
-      dotnet user-secrets set "AIConfiguration:GenerativeAI:Azure:CompletionModelName" "YOUR gpt-3.5-turbo-instruct DEPLOYMENT NAME"
-      dotnet user-secrets set "AIConfiguration:GenerativeAI:Azure:ChatModelName" "YOUR gpt-4 DEPLOYMENT NAME"
-      dotnet user-secrets set "AIConfiguration:GenerativeAI:Azure:EmbeddingModelName" "YOUR text-embedding-ada-002 DEPLOYMENT NAME"
 
-    ```
+#### Configuration Validations:
+Ensure that the `OpenAiConfigs` section in `config/settings.json` is correctly configured, following these rules:
+
+1. The `OpenAiConfigs` section must exist and contain valid configurations.
+2. Ensure there are no duplicate `ServiceId`s within the `OpenAiConfigs` array.
+3. For each configuration within `OpenAiConfigs`:
+   - `ApiType` must be specified and its value must be either `openai` or `azure`.
+   - `ApiKey` must be specified.
+   - If `ApiType` is `openai`, `OrgId` must also be specified.
+   - If `ApiType` is `azure`, `BaseUrl`, `ModelId`, and `ModelType` must be specified.
+   - If `ApiType` is `azure`, `ModelType` must be either `completions` or `embeddings`.
+4. You must deploy at least one model greater or equal to GPT-3.5 Turbo, ideally GPT-4.
+5. You must deploy at least one embeddings model.
+
+#### Setup Config:
+- To set up configuration values using `config/settings.json`:
+  ```json
+  "OpenAiConfigs": [
+      {
+          "ApiType": "azure",
+          "ApiKey": "<your Azure OpenAI API key here>",
+          "BaseUrl": "<your Azure OpenAI API base here>",
+          "ModelId": "<deployment id for the model>",
+          "ModelType": "<must be completions or embeddings>",
+          "ServiceId": ""
+      }
+  ]
+  ```
 
 #### Learn More:
 - [Official Documentation](https://learn.microsoft.com/en-us/azure/cognitive-services/openai-service/)
@@ -222,18 +230,11 @@ Click this button to deploy a `Bing Search` service:
 - In the left pane, select **Keys and Endpoint**.
 - Here, you can access the primary and secondary keys for your Bing Search service. Copy either **Key1** or **Key2** as needed for your application.
 - Setup Config:
-  - To set up configuration values using `settings.json`:
+  - To set up configuration values using `config/settings.json`:
     ```json
-    "AIConfiguration": {
-      "BingSearch": {
+    "BingSearchConfig": {
         "ApiKey": "<YOUR_BING_API_KEY>"
-      }
     }
-    ```
-    
-  - Or using .NET user secrets
-    ```cmd
-    dotnet user-secrets set "AIConfiguration:BingSearch:ApiKey" "<YOUR_BING_API_KEY>"
     ```
 
 #### Learn More:

--- a/config/dotnet/ConfigHelper.cs
+++ b/config/dotnet/ConfigHelper.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+
+public class ConfigurationHelper
+{
+    private readonly string _configuration;
+    private readonly CopilotAppConfig appConfig;
+
+    private string pathToConfigFile = "../../../config/settings.json";
+
+    public ConfigurationHelper(string path):this()
+    {
+        pathToConfigFile = path;
+    }
+    public ConfigurationHelper()
+    {        
+        if (!System.IO.File.Exists(pathToConfigFile))
+        {
+            throw new Exception($"The configuration file {pathToConfigFile} does not exist.");
+        }
+        else
+        {
+            _configuration = System.IO.File.ReadAllText(pathToConfigFile);            
+            appConfig = JsonSerializer.Deserialize<CopilotAppConfig>(_configuration, new JsonSerializerOptions
+            {
+                ReadCommentHandling = JsonCommentHandling.Skip,
+                AllowTrailingCommas = true,
+            });
+            ValidateConfigurations();
+        }
+    }
+
+    public CopilotAppConfig GetConfiguration()
+    {
+        return appConfig;
+    }
+
+
+    public void ValidateConfigurations()
+    {
+        ValidateOpenAiConfigurations(appConfig.OpenAiConfigs);
+        ValidateAzureSearchConfig(appConfig.AzureSearchConfig);
+        ValidateBingSearchConfig(appConfig.BingSearchConfig);
+    }
+
+    private void ValidateAzureSearchConfig(AzureSearchConfig azureSearchConfig)
+    {
+        if (azureSearchConfig == null || string.IsNullOrEmpty(azureSearchConfig.Endpoint) || string.IsNullOrEmpty(azureSearchConfig.AdminKey))
+            throw new Exception("AzureSearchConfig section is missing or invalid. Please ensure the section exists and Endpoint and AdminKey are properly configured.");
+    }
+
+    private void ValidateBingSearchConfig(BingSearchConfig bingSearchConfig)
+    {
+        if (bingSearchConfig == null || string.IsNullOrEmpty(bingSearchConfig.ApiKey))
+            throw new Exception("BingSearchConfig section is missing or invalid. Please ensure the section exists and ApiKey is properly configured.");
+    }
+
+    private void ValidateOpenAiConfigurations(List<OpenAiConfiguration> openAiConfigs)
+{
+    if (openAiConfigs == null || !openAiConfigs.Any())
+        throw new Exception("OpenAiConfigurations section is missing or invalid. Please ensure the section exists and contains valid configurations.");
+
+    // Check for duplicate ServiceIds
+    var duplicateServiceIds = openAiConfigs.GroupBy(config => config.ServiceId)
+                                           .Where(group => group.Count() > 1)
+                                           .Select(group => group.Key)
+                                           .ToList();
+
+    if (duplicateServiceIds.Any())
+        throw new Exception($"Duplicate ServiceId(s) found: {string.Join(", ", duplicateServiceIds)}.");
+
+    foreach (var config in openAiConfigs)
+    {
+        if (string.IsNullOrEmpty(config.ApiType) || (config.ApiType != "openai" && config.ApiType != "azure"))
+            throw new Exception($"Invalid ApiType '{config.ApiType}' in OpenAiConfigurations. Allowed values are 'openai' and 'azure'.");
+
+        if (string.IsNullOrEmpty(config.ApiKey))
+            throw new Exception($"ApiKey is missing for configuration index {openAiConfigs.IndexOf(config)} in OpenAiConfigurations.");
+
+        if (config.ApiType == "openai" && string.IsNullOrEmpty(config.OrgId))
+            throw new Exception($"Invalid OpenAi specific configurations for configuration index {openAiConfigs.IndexOf(config)} in OpenAiConfigurations. Please ensure OrgId is properly configured.");
+
+        if (config.ApiType == "azure" && string.IsNullOrEmpty(config.BaseUrl))
+            throw new Exception($"Invalid Azure specific configurations for configuration index {openAiConfigs.IndexOf(config)} in OpenAiConfigurations. Please ensure BaseUrl is properly configured.");
+
+        if (config.ApiType == "azure" && string.IsNullOrEmpty(config.ModelId))
+            throw new Exception($"Invalid Azure specific configurations for configuration index {openAiConfigs.IndexOf(config)} in OpenAiConfigurations. Please ensure ModelId (a.k.a Deployment Id) is properly configured.");
+
+        if (config.ApiType == "azure" && (string.IsNullOrEmpty(config.ModelType) || (config.ModelType != "embeddings" && config.ModelType != "completions")))
+            throw new Exception($"Invalid Azure specific configurations for configuration index {openAiConfigs.IndexOf(config)} in OpenAiConfigurations. Please ensure ModelType is properly configured. Allowed values are 'completions' and 'embeddings'.");
+    }
+}
+
+}

--- a/config/dotnet/ConfigModels.cs
+++ b/config/dotnet/ConfigModels.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+
+public class OpenAiConfiguration
+{
+    public string ApiType { get; set; }
+    public string ApiKey { get; set; }
+    public string OrgId { get; set; }
+    public string BaseUrl { get; set; }
+    public string ModelId { get; set; }
+    public string ModelType { get; set; }
+    public string ServiceId { get; set; }
+}
+
+public class AzureSearchConfig
+{
+    public string Endpoint { get; set; }
+    public string AdminKey { get; set; }
+}
+
+public class BingSearchConfig
+{
+    public string ApiKey { get; set; }
+}
+
+public class CopilotAppConfig
+{
+    public List<OpenAiConfiguration> OpenAiConfigs { get; set; }
+    public AzureSearchConfig AzureSearchConfig { get; set; }
+    public BingSearchConfig BingSearchConfig { get; set; }    
+}

--- a/config/dotnet/KernelHelper.cs
+++ b/config/dotnet/KernelHelper.cs
@@ -1,0 +1,77 @@
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Reliability.Basic;
+
+public static class KernelHelper
+{
+    public static IKernel LoadKernel()
+    {
+        var configuration = new ConfigurationHelper().GetConfiguration();
+
+        var builder = new KernelBuilder();
+
+        var defaultCompletion = true;
+
+        // Loop through OpenAiConfigurations 
+        foreach (var openAiConfig in configuration.OpenAiConfigs)
+        {
+            if (openAiConfig.ApiType == "azure")
+            {
+                if (openAiConfig.ModelType == "completions")
+                {
+                    builder.WithAzureChatCompletionService(
+                        openAiConfig.ModelId,       // Azure OpenAI deployment name.
+                        openAiConfig.BaseUrl,       // Azure OpenAI deployment URL.
+                        openAiConfig.ApiKey,        // Azure OpenAI API key.
+                        true,                       // Whether to use the service also for text completion, if supported.
+                        openAiConfig.ServiceId,     // A local identifier for the given AI service.                    
+                        defaultCompletion           // Whether the service should be the default for its type.
+                    );
+                    if (defaultCompletion) { defaultCompletion = false; }
+                }
+                if (openAiConfig.ModelType == "embeddings")
+                {
+                    builder.WithAzureTextEmbeddingGenerationService(
+                        openAiConfig.ModelId,       // Azure OpenAI deployment name.
+                        openAiConfig.BaseUrl,       // Azure OpenAI deployment URL.
+                        openAiConfig.ApiKey,        // Azure OpenAI API key.                        
+                        openAiConfig.ServiceId,     // A local identifier for the given AI service.                    
+                        true                        // Whether the service should be the default for its type.
+                    );
+                }
+            }
+
+            // Check if the ApiType is OpenAi
+            if (openAiConfig.ApiType == "openai")
+            {
+                if (openAiConfig.ModelType == "completions")
+                {
+                    builder.WithOpenAIChatCompletionService(
+                        openAiConfig.ModelId,       // OpenAI model name.
+                        openAiConfig.ApiKey,        // OpenAI API key.
+                        openAiConfig.OrgId,         // OpenAI organization id.              
+                        openAiConfig.ServiceId,     // A local identifier for the given AI service.                    
+                        true                        // Whether to use the service also for text completion, if supported.
+                    );
+                }
+                if (openAiConfig.ModelType == "embeddings")
+                {
+                    builder.WithOpenAITextEmbeddingGenerationService(
+                        openAiConfig.ModelId,       // OpenAI model name.
+                        openAiConfig.ApiKey,        // OpenAI API key.
+                        openAiConfig.OrgId,         // OpenAI organization id.              
+                        openAiConfig.ServiceId      // A local identifier for the given AI service.                                          
+                    );
+                }
+            }
+        }
+
+
+        builder.WithRetryBasic(new BasicRetryConfig
+        {
+            MaxRetryCount = 3,
+            UseExponentialBackoff = true,
+        });
+
+        return builder.Build();
+    }
+}

--- a/config/dotnet/KernelHelper.cs
+++ b/config/dotnet/KernelHelper.cs
@@ -226,18 +226,40 @@ public static class KernelHelper
         return list;
     }
 
-    public static void Print(KernelResult r)
+    public static void Print(KernelResult r, PrintElement element = PrintElement.Paragraph)
     {
-        Print(r.GetValue<string>());        
+        Print(r.GetValue<string>(), element);
     }
 
-    public static void Print(FunctionResult r)
+    public static void Print(FunctionResult r, PrintElement element = PrintElement.Paragraph)
     {
-         Print(r.GetValue<string>());
+        Print(r.GetValue<string>(), element);
     }
 
-    public static void Print(string text)
+    public static void Print(string text, PrintElement element)
     {
-        display(p[style:"color:#FF4500"](text));
+        // Important to escape any HTML tags in the text
+        text = text.Replace("<", "&lt;").Replace(">", "&gt;");
+             
+        var style = "color:#a0d2eb;background-color:#8458B3;padding:10px;border-radius:5px;";
+        switch(element)
+        {
+            case PrintElement.Header:                      
+                display(p[style:$"{style};font-weight:bolder;text-decoration:underline;"](text));
+                break;
+            case PrintElement.Paragraph:                
+                display(p[style:style](text));
+                break;
+            case PrintElement.Pre:                
+                display(div[style:$"{style}font-family: monospace;"](span[style:$"white-space:pre;color:black!important;background-color:#a0d2eb!important"](text)));
+                break;
+        }
     }
+}
+
+public enum PrintElement 
+{
+    Header,
+    Paragraph,
+    Pre
 }

--- a/config/dotnet/KernelHelper.cs
+++ b/config/dotnet/KernelHelper.cs
@@ -1,5 +1,8 @@
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.Reliability.Basic;
+using Microsoft.SemanticKernel.Plugins.Core;
+using Microsoft.SemanticKernel.Plugins.Web;
+using Microsoft.SemanticKernel.Plugins.Web.Bing;
 
 public static class KernelHelper
 {
@@ -72,6 +75,75 @@ public static class KernelHelper
             UseExponentialBackoff = true,
         });
 
-        return builder.Build();
+        var kernel = builder.Build();
+
+        // Add the Bing search engine if the API key is provided.
+        if(configuration.BingSearchConfig != null && !string.IsNullOrEmpty(configuration.BingSearchConfig.ApiKey))
+        {
+            kernel.ImportFunctions(new WebSearchEnginePlugin(new BingConnector(configuration.BingSearchConfig.ApiKey)), "bing");
+        }
+
+        // Adding Text Plugin. See: https://github.com/microsoft/semantic-kernel/blob/main/dotnet/src/Plugins/Plugins.Core/TextPlugin.cs
+        // SKContext.Variables["input"] = "  hello world  "
+        // {{text.trim $input}} => "hello world"
+        // {{text.trimStart $input} => "hello world  "
+        // {{text.trimEnd $input} => "  hello world"
+        // SKContext.Variables["input"] = "hello world"
+        // {{text.uppercase $input}} => "HELLO WORLD"
+        // SKContext.Variables["input"] = "HELLO WORLD"
+        // {{text.lowercase $input}} => "hello world"
+        kernel.ImportFunctions(new TextPlugin(), "text");
+
+        // Adding Time Plugin. See: https://github.com/microsoft/semantic-kernel/blob/main/dotnet/src/Plugins/Plugins.Core/TimePlugin.cs
+        // Examples:
+        // {{time.date}}            => Sunday, 12 January, 2031
+        // {{time.today}}           => Sunday, 12 January, 2031
+        // {{time.now}}             => Sunday, January 12, 2031 9:15 PM
+        // {{time.utcNow}}          => Sunday, January 13, 2031 5:15 AM
+        // {{time.time}}            => 09:15:07 PM
+        // {{time.year}}            => 2031
+        // {{time.month}}           => January
+        // {{time.monthNumber}}     => 01
+        // {{time.day}}             => 12
+        // {{time.dayOfMonth}}      => 12
+        // {{time.dayOfWeek}}       => Sunday
+        // {{time.hour}}            => 9 PM
+        // {{time.hourNumber}}      => 21
+        // {{time.daysAgo $days}}   => Sunday, January 12, 2025 9:15 PM
+        // {{time.lastMatchingDay $dayName}} => Sunday, 7 May, 2023
+        // {{time.minute}}          => 15
+        // {{time.minutes}}         => 15
+        // {{time.second}}          => 7
+        // {{time.seconds}}         => 7
+        // {{time.timeZoneOffset}}  => -08:00
+        // {{time.timeZoneName}}    => PST
+        kernel.ImportFunctions(new TimePlugin(), "time"); 
+
+        // Adding Wait Plugin. See: https://github.com/microsoft/semantic-kernel/blob/main/dotnet/src/Plugins/Plugins.Core/WaitPlugin.cs
+        // Examples:
+        // {{wait.seconds 10}} => Wait 10 seconds
+        kernel.ImportFunctions(new WaitPlugin(), "wait");
+
+        // Adding Math Plugin. See: https://github.com/microsoft/semantic-kernel/blob/main/dotnet/src/Plugins/Plugins.Core/MathPlugin.cs
+        // Examples:
+        // {{math.Add}} => FirstNumber + SecondNumber  (provided in the SKContext)
+        // {{math.Subtract}} => FirstNumber - SecondNumber (provided in the SKContext)
+        kernel.ImportFunctions(new MathPlugin(), "math");
+
+        // Adding Http Plugin. See: https://github.com/microsoft/semantic-kernel/blob/main/dotnet/src/Plugins/Plugins.Core/HttpPlugin.cs
+        // Examples:
+        // {{http.getAsync $url}}
+        // {{http.postAsync $url}}
+        // {{http.putAsync $url}}
+        // {{http.deleteAsync $url}}
+        kernel.ImportFunctions(new HttpPlugin(), "http");
+
+        // Adding FileIO Plugin. See: https://github.com/microsoft/semantic-kernel/blob/main/dotnet/src/Plugins/Plugins.Core/FileIOPlugin.cs
+        // Examples:
+        // {{file.readAsync $path }} => "hello world"
+        // {{file.writeAsync}}        
+        kernel.ImportFunctions(new FileIOPlugin(), "file");
+
+        return kernel;
     }
 }

--- a/config/dotnet/StringHelpers.cs
+++ b/config/dotnet/StringHelpers.cs
@@ -26,5 +26,5 @@ public static class Utils
     public static void Print(string text)
     {
         Console.WriteLine(Wrap(text, 100));
-    }
+    }    
 }

--- a/config/dotnet/StringHelpers.cs
+++ b/config/dotnet/StringHelpers.cs
@@ -1,0 +1,30 @@
+using System.IO;
+using System.Text.Json;
+
+public static class Utils
+{
+    // Function used to wrap long lines of text
+    public static string Wrap(string text, int maxLineLength)
+    {
+        var result = new StringBuilder();
+        int i;
+        var last = 0;
+        var space = new[] { ' ', '\r', '\n', '\t' };
+        do
+        {
+            i = last + maxLineLength > text.Length
+                ? text.Length
+                : (text.LastIndexOfAny(new[] { ' ', ',', '.', '?', '!', ':', ';', '-', '\n', '\r', '\t' }, Math.Min(text.Length - 1, last + maxLineLength)) + 1);
+            if (i <= last) i = Math.Min(last + maxLineLength, text.Length);
+            result.AppendLine(text.Substring(last, i - last).Trim(space));
+            last = i;
+        } while (i < text.Length);
+
+        return result.ToString();
+    }
+
+    public static void Print(string text)
+    {
+        Console.WriteLine(Wrap(text, 100));
+    }
+}

--- a/config/settings.json.sample
+++ b/config/settings.json.sample
@@ -12,7 +12,7 @@
             // Deployment ID for the model; only required when ApiType is "azure".
             "ModelId": "<deployment id for the model. Only required when type is azure>",
             // Specifies the type of model to use; either "completion" or "embeddings". Only required when ApiType is "azure".
-            "ModelType": "<must be completion or embeddings. Only required when type is azure>",
+            "ModelType": "<must be completions or embeddings. Only required when type is azure>",
             // An optional service ID.
             "ServiceId": ""
         }

--- a/config/settings.json.sample
+++ b/config/settings.json.sample
@@ -1,0 +1,36 @@
+{
+  "OpenAiConfigs": [
+      {
+          // Specifies the type of API to use; either "openai" or "azure".
+          "ApiType": "<must be openai or azure>", 
+
+          // Your API key for OpenAI or Azure.
+          "ApiKey": "<your OpenAI API key here>", 
+
+          // The base URL for the Azure OpenAI API; only required when ApiType is "azure".
+          "BaseUrl": "<your Azure OpenAI API base here. Only required when type is azure>", 
+
+          // Deployment ID for the model; only required when ApiType is "azure".
+          "ModelId": "<deployment id for the model. Only required when type is azure>", 
+
+          // Specifies the type of model to use; either "completion" or "embeddings". Only required when ApiType is "azure".
+          "ModelType": "<must be completion or embeddings. Only required when type is azure>", 
+
+          // An optional service ID.
+          "ServiceId": ""        
+      }
+  ],  
+  // Configuration settings for Azure Search Service.
+  "AzureSearchConfig": {
+      // The endpoint URL for the Azure Search Service.
+      "Endpoint": "",
+
+      // Your admin key for authenticating requests to the Azure Search Service.
+      "AdminKey": ""
+  },
+  // Configuration settings for Bing Search Service.
+  "BingSearchConfig": {
+      // Your API key for authenticating requests to the Bing Search Service.
+      "ApiKey": ""
+  }
+}

--- a/config/settings.json.sample
+++ b/config/settings.json.sample
@@ -1,36 +1,32 @@
 {
-  "OpenAiConfigs": [
-      {
-          // Specifies the type of API to use; either "openai" or "azure".
-          "ApiType": "<must be openai or azure>", 
-
-          // Your API key for OpenAI or Azure.
-          "ApiKey": "<your OpenAI API key here>", 
-
-          // The base URL for the Azure OpenAI API; only required when ApiType is "azure".
-          "BaseUrl": "<your Azure OpenAI API base here. Only required when type is azure>", 
-
-          // Deployment ID for the model; only required when ApiType is "azure".
-          "ModelId": "<deployment id for the model. Only required when type is azure>", 
-
-          // Specifies the type of model to use; either "completion" or "embeddings". Only required when ApiType is "azure".
-          "ModelType": "<must be completion or embeddings. Only required when type is azure>", 
-
-          // An optional service ID.
-          "ServiceId": ""        
-      }
-  ],  
-  // Configuration settings for Azure Search Service.
-  "AzureSearchConfig": {
-      // The endpoint URL for the Azure Search Service.
-      "Endpoint": "",
-
-      // Your admin key for authenticating requests to the Azure Search Service.
-      "AdminKey": ""
-  },
-  // Configuration settings for Bing Search Service.
-  "BingSearchConfig": {
-      // Your API key for authenticating requests to the Bing Search Service.
-      "ApiKey": ""
-  }
+    "OpenAiConfigs": [
+        {
+            // Specifies the type of API to use; either "openai" or "azure".
+            "ApiType": "<must be openai or azure>",
+            // Your API key for OpenAI or Azure.
+            "ApiKey": "<your OpenAI API key here>",
+            // Your Org Id for OpenAI; only required when ApiType is "openai".
+            "OrgId": "<your OpenAI OrgId here. Only required when type is openai>",
+            // The base URL for the Azure OpenAI API; only required when ApiType is "azure".
+            "BaseUrl": "<your Azure OpenAI API base here. Only required when type is azure>",
+            // Deployment ID for the model; only required when ApiType is "azure".
+            "ModelId": "<deployment id for the model. Only required when type is azure>",
+            // Specifies the type of model to use; either "completion" or "embeddings". Only required when ApiType is "azure".
+            "ModelType": "<must be completion or embeddings. Only required when type is azure>",
+            // An optional service ID.
+            "ServiceId": ""
+        }
+    ],
+    // Configuration settings for Azure Search Service.
+    "AzureSearchConfig": {
+        // The endpoint URL for the Azure Search Service.
+        "Endpoint": "",
+        // Your admin key for authenticating requests to the Azure Search Service.
+        "AdminKey": ""
+    },
+    // Configuration settings for Bing Search Service.
+    "BingSearchConfig": {
+        // Your API key for authenticating requests to the Bing Search Service.
+        "ApiKey": ""
+    }
 }

--- a/notebooks/dotnet/sample/sample-notebook.ipynb
+++ b/notebooks/dotnet/sample/sample-notebook.ipynb
@@ -1,0 +1,549 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Sample Notebook using the latest version of the SDK (v1.0.0-beta4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 1: Load required libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "vscode": {
+     "languageId": "polyglot-notebook"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Microsoft.SemanticKernel, 1.0.0-beta4</span></li><li><span>Microsoft.SemanticKernel.Connectors.Memory.AzureCognitiveSearch, 1.0.0-beta4</span></li><li><span>Microsoft.SemanticKernel.Plugins.Core, 1.0.0-beta4</span></li><li><span>Microsoft.SemanticKernel.Plugins.Memory, 1.0.0-beta4</span></li><li><span>Microsoft.SemanticKernel.Plugins.Web, 1.0.0-beta4</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#r \"nuget: Microsoft.SemanticKernel, 1.0.0-beta4\"\n",
+    "#r \"nuget: Microsoft.SemanticKernel.Plugins.Core, 1.0.0-beta4\"\n",
+    "#r \"nuget: Microsoft.SemanticKernel.Plugins.Web, 1.0.0-beta4\"\n",
+    "#r \"nuget: Microsoft.SemanticKernel.Plugins.Memory, 1.0.0-beta4\"\n",
+    "#r \"nuget: Microsoft.SemanticKernel.Connectors.Memory.AzureCognitiveSearch, 1.0.0-beta4\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2: Setup Kernel"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Import files from the `config` directory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "vscode": {
+     "languageId": "polyglot-notebook"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "#!import ../../../config/dotnet/ConfigModels.cs\n",
+    "#!import ../../../config/dotnet/ConfigHelper.cs\n",
+    "#!import ../../../config/dotnet/KernelHelper.cs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Display the current configuration (Optional).\n",
+    "> **⚠️ Note ☠️:** This is useful to check the current configuration. But be sure to comment this out & clear the output before committing the notebook. You don't want to commit your credentials. ⚠️"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "vscode": {
+     "languageId": "polyglot-notebook"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "// Note: Comment this out & clear the output before committing the notebook. \n",
+    "// You don't want to commit your credentials. \n",
+    "// new ConfigurationHelper().GetConfiguration().Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Load the kernel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "vscode": {
+     "languageId": "polyglot-notebook"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<details open=\"open\" class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>Microsoft.SemanticKernel.Kernel</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>LoggerFactory</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory</code></span></summary><div><table><thead><tr></tr></thead><tbody></tbody></table></div></details></td></tr><tr><td>Functions</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>Microsoft.SemanticKernel.FunctionCollection</code></span></summary><div><table><thead><tr></tr></thead><tbody></tbody></table></div></details></td></tr><tr><td>PromptTemplateEngine</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>Microsoft.SemanticKernel.TemplateEngine.Basic.BasicPromptTemplateEngine</code></span></summary><div><table><thead><tr></tr></thead><tbody></tbody></table></div></details></td></tr><tr><td>HttpHandlerFactory</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>Microsoft.SemanticKernel.Reliability.Basic.BasicHttpRetryHandlerFactory</code></span></summary><div><table><thead><tr></tr></thead><tbody></tbody></table></div></details></td></tr><tr><td>Memory</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>Microsoft.SemanticKernel.Memory.SemanticTextMemory</code></span></summary><div><table><thead><tr></tr></thead><tbody></tbody></table></div></details></td></tr><tr><td>Skills</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>Microsoft.SemanticKernel.FunctionCollection</code></span></summary><div><table><thead><tr></tr></thead><tbody></tbody></table></div></details></td></tr></tbody></table></div></details><style>\r\n",
+       ".dni-code-hint {\r\n",
+       "    font-style: italic;\r\n",
+       "    overflow: hidden;\r\n",
+       "    white-space: nowrap;\r\n",
+       "}\r\n",
+       ".dni-treeview {\r\n",
+       "    white-space: nowrap;\r\n",
+       "}\r\n",
+       ".dni-treeview td {\r\n",
+       "    vertical-align: top;\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "details.dni-treeview {\r\n",
+       "    padding-left: 1em;\r\n",
+       "}\r\n",
+       "table td {\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "table tr { \r\n",
+       "    vertical-align: top; \r\n",
+       "    margin: 0em 0px;\r\n",
+       "}\r\n",
+       "table tr td pre \r\n",
+       "{ \r\n",
+       "    vertical-align: top !important; \r\n",
+       "    margin: 0em 0px !important;\r\n",
+       "} \r\n",
+       "table th {\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "</style>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "var kernel = KernelHelper.LoadKernel();\n",
+    "kernel.Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Display all available functions (via enabled plugins)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "vscode": {
+     "languageId": "polyglot-notebook"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = GitHubSearchUrl, PluginName = url, Description = Return URL for GitHub search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>GitHubSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for GitHub search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>1</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = WikipediaSearchUrl, PluginName = url, Description = Return URL for Wikipedia search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>WikipediaSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Wikipedia search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>2</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = BingShoppingSearchUrl, PluginName = url, Description = Return URL for Bing Shopping search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>BingShoppingSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Bing Shopping search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>3</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = BingImagesSearchUrl, PluginName = url, Description = Return URL for Bing Images search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>BingImagesSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Bing Images search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>4</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = FacebookSearchUrl, PluginName = url, Description = Return URL for Facebook search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>FacebookSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Facebook search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>5</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = BingSearchUrl, PluginName = url, Description = Return URL for Bing search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>BingSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Bing search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>6</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = BingNewsSearchUrl, PluginName = url, Description = Return URL for Bing News search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>BingNewsSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Bing News search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>7</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = LinkedInSearchUrl, PluginName = url, Description = Return URL for LinkedIn search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>LinkedInSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for LinkedIn search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>8</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = AmazonSearchUrl, PluginName = url, Description = Return URL for Amazon search query, Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>AmazonSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Amazon search query</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>9</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = BingMapsSearchUrl, PluginName = url, Description = Return URL for Bing Maps search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>BingMapsSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Bing Maps search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>10</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = TwitterSearchUrl, PluginName = url, Description = Return URL for Twitter search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>TwitterSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Twitter search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>11</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = BingTravelSearchUrl, PluginName = url, Description = Return URL for Bing Travel search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>BingTravelSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Bing Travel search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>12</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = Seconds, PluginName = wait, Description = Wait a given amount of seconds, Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>Seconds</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>wait</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Wait a given amount of seconds</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = seconds, Description = The number of seconds to wait, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>seconds</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>The number of seconds to wait</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>13</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = Trim, PluginName = text, Description = Trim whitespace from the start and end of a string., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>Trim</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>text</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Trim whitespace from the start and end of a string.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = input, Description = , DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>input</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>14</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = Echo, PluginName = text, Description = Echo the input string. Useful for capturing plan input for use in multiple functions., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>Echo</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>text</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Echo the input string. Useful for capturing plan input for use in multiple functions.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = text, Description = Input string to echo., DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>text</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Input string to echo.</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>15</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = Concat, PluginName = text, Description = Concat two strings into one., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>Concat</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>text</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Concat two strings into one.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = input, Description = First input to concatenate with, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>input</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>First input to concatenate with</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>1</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = input2, Description = Second input to concatenate with, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>input2</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Second input to concatenate with</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>16</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = Uppercase, PluginName = text, Description = Convert a string to uppercase., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>Uppercase</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>text</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Convert a string to uppercase.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = input, Description = , DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>input</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>17</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = Lowercase, PluginName = text, Description = Convert a string to lowercase., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>Lowercase</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>text</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Convert a string to lowercase.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = input, Description = , DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>input</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>18</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = TrimStart, PluginName = text, Description = Trim whitespace from the start of a string., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>TrimStart</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>text</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Trim whitespace from the start of a string.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = input, Description = , DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>input</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>19</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = Length, PluginName = text, Description = Get the length of a string., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>Length</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>text</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Get the length of a string.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = input, Description = , DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>input</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td colspan=\"2\"><i>(29 more)</i></td></tr></tbody></table><style>\r\n",
+       ".dni-code-hint {\r\n",
+       "    font-style: italic;\r\n",
+       "    overflow: hidden;\r\n",
+       "    white-space: nowrap;\r\n",
+       "}\r\n",
+       ".dni-treeview {\r\n",
+       "    white-space: nowrap;\r\n",
+       "}\r\n",
+       ".dni-treeview td {\r\n",
+       "    vertical-align: top;\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "details.dni-treeview {\r\n",
+       "    padding-left: 1em;\r\n",
+       "}\r\n",
+       "table td {\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "table tr { \r\n",
+       "    vertical-align: top; \r\n",
+       "    margin: 0em 0px;\r\n",
+       "}\r\n",
+       "table tr td pre \r\n",
+       "{ \r\n",
+       "    vertical-align: top !important; \r\n",
+       "    margin: 0em 0px !important;\r\n",
+       "} \r\n",
+       "table th {\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "</style>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "kernel.Functions.GetFunctionViews().Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3: Test Completions by creating a simple inline function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "vscode": {
+     "languageId": "polyglot-notebook"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "The sky appears blue because of a process called Rayleigh scattering. As sunlight reaches Earth's atmosphere, it is made up of different colors that are represented in a rainbow, or light spectrum. These colors are differentiated by their wavelengths. Blue and violet light have the shortest wavelengths and are scattered in all directions by the gas molecules in Earth's atmosphere.\n",
+       "\n",
+       "Blue light is scattered more than other colors because it travels in smaller, shorter waves. This scattering causes the sky to appear blue in our perception. However,"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "The color of the ocean can vary and is influenced by several factors. It can appear green due to the presence of large amounts of algae or phytoplankton, tiny plant-like organisms that contain chlorophyll. When sunlight hits the water, it can be absorbed or reflected. Chlorophyll in phytoplankton absorbs light, particularly in the red and blue parts of the light spectrum, and reflects green light. This reflected light is what we see, which can give the ocean a green appearance"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "using Microsoft.SemanticKernel.Connectors.AI.OpenAI;\n",
+    "\n",
+    "// 1. define the function called \"ask\"\n",
+    "var askFunction = kernel.CreateSemanticFunction(\n",
+    "    promptTemplate: \"{{$input}}\", \n",
+    "    requestSettings: new OpenAIRequestSettings() { \n",
+    "        MaxTokens = 100, \n",
+    "        Temperature = 0.4, \n",
+    "        TopP = 1,\n",
+    "        // Here I have specified the service id. \n",
+    "        // Comment this out if you would like to use the default service id.\n",
+    "        // ServiceId = \"oai-gpt-4-0613\" \n",
+    "    },\n",
+    "    functionName: \"ask\");\n",
+    "\n",
+    "// 2. call the function directly using the function object\n",
+    "var directResult = await kernel.RunAsync(\"Why is the sky blue?\", askFunction);\n",
+    "directResult.GetValue<string>().Display();\n",
+    "\n",
+    "// ALTERNATIVELY\n",
+    "// 2. call the function by name using the kernel.\n",
+    "var nameResult = await kernel.Functions.GetFunction(\"ask\").InvokeAsync(\"why is the ocean green?\", kernel);\n",
+    "nameResult.GetValue<string>().Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 4: Test Core Plugins"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "4.1: Text plugin"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "vscode": {
+     "languageId": "polyglot-notebook"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "hello world"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  hello world"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "var r = await kernel.Functions.GetFunction(\"text\", \"trim\").InvokeAsync(\"  hello world  \", kernel);\n",
+    "r.GetValue<string>().Display();\n",
+    "\n",
+    "r = await kernel.Functions.GetFunction(\"text\", \"trimEnd\").InvokeAsync(\"  hello world  \", kernel);\n",
+    "r.GetValue<string>().Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "4.1: This is a continuation of the previous step. Here we see how to \"chain\" plugins together. We call the \"ask\" plugin & pass the output to the \"text\" plugin where we can see the output in uppercase."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "vscode": {
+     "languageId": "polyglot-notebook"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "WHY DON'T SCIENTISTS TRUST ATOMS? BECAUSE THEY MAKE UP EVERYTHING!"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "var r = await kernel.RunAsync(\n",
+    "    \"Tell me 1 sentence joke.\",\n",
+    "    kernel.Functions.GetFunction(\"ask\"),\n",
+    "    kernel.Functions.GetFunction(\"text\", \"uppercase\")\n",
+    ");\n",
+    "r.GetValue<string>().Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 5: Test Web Plugins"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "vscode": {
+     "languageId": "polyglot-notebook"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<details open=\"open\" class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[&quot;The annual inflation rate for the United States was 3.7% for the 12 months ended September, according to U.S. Labor Department data published on Oct. 12, 2023. This was the same as the 3.7% in the previous period. The next update on inflation is scheduled for release on Nov. 14 at 8:30 a.m. ET.&quot;,&quot;...</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>FunctionName</td><td><div class=\"dni-plaintext\"><pre>Search</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>bing</pre></div></td></tr><tr><td>Metadata</td><td><i>(empty)</i></td></tr></tbody></table></div></details><style>\r\n",
+       ".dni-code-hint {\r\n",
+       "    font-style: italic;\r\n",
+       "    overflow: hidden;\r\n",
+       "    white-space: nowrap;\r\n",
+       "}\r\n",
+       ".dni-treeview {\r\n",
+       "    white-space: nowrap;\r\n",
+       "}\r\n",
+       ".dni-treeview td {\r\n",
+       "    vertical-align: top;\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "details.dni-treeview {\r\n",
+       "    padding-left: 1em;\r\n",
+       "}\r\n",
+       "table td {\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "table tr { \r\n",
+       "    vertical-align: top; \r\n",
+       "    margin: 0em 0px;\r\n",
+       "}\r\n",
+       "table tr td pre \r\n",
+       "{ \r\n",
+       "    vertical-align: top !important; \r\n",
+       "    margin: 0em 0px !important;\r\n",
+       "} \r\n",
+       "table th {\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "</style>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "var webQuery = \"What is the inflation rate in the US in September 2023?\";\n",
+    "\n",
+    "var inflationData = await kernel.Functions.GetFunction(\"bing\", \"search\").InvokeAsync(webQuery, kernel);\n",
+    "\n",
+    "inflationData.Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 6: Test Memories"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "vscode": {
+     "languageId": "polyglot-notebook"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Has tentacles? - Octopus\n"
+     ]
+    }
+   ],
+   "source": [
+    "var db = \"random-animals\";\n",
+    "\n",
+    "await kernel.Memory.SaveInformationAsync(\n",
+    "    db, id: \"1\", text: \"Dog\");\n",
+    "await kernel.Memory.SaveInformationAsync(\n",
+    "    db, id: \"2\", text: \"Elephant\");\n",
+    "await kernel.Memory.SaveInformationAsync(\n",
+    "    db, id: \"3\", text: \"Octopus\");\n",
+    "\n",
+    "var memorySearch = \"Has tentacles?\";\n",
+    "await foreach (var item in kernel.Memory.SearchAsync(\n",
+    "    collection: db, \n",
+    "    query: memorySearch, \n",
+    "    limit: 1, \n",
+    "    minRelevanceScore: 0.5))\n",
+    "{\n",
+    "    Console.WriteLine($\"{memorySearch} - {item.Metadata.Text}\");\n",
+    "}\n",
+    "\n",
+    "await kernel.Memory.RemoveAsync(db,\"1\");\n",
+    "await kernel.Memory.RemoveAsync(db,\"2\");\n",
+    "await kernel.Memory.RemoveAsync(db,\"3\");"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/dotnet/sample/sample-notebook.ipynb
+++ b/notebooks/dotnet/sample/sample-notebook.ipynb
@@ -48,6 +48,26 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "vscode": {
+     "languageId": "polyglot-notebook"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "// Enable the display of HTML content in the notebook\n",
+    "using static Microsoft.DotNet.Interactive.Formatting.PocketViewTags;"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -63,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -88,12 +108,12 @@
    "metadata": {},
    "source": [
     "Display the current configuration (Optional).\n",
-    "> **⚠️ Note ☠️:** This is useful to check the current configuration. But be sure to comment this out & clear the output before committing the notebook. You don't want to commit your credentials. ⚠️"
+    "> **⚠️ Note ☠️:** This is useful to check the current configuration. But be sure to comment this out & clear the output before committing the notebook. You don't want to commit your credentials. ⚠️\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -121,7 +141,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -189,7 +209,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -204,8 +224,66 @@
    "outputs": [
     {
      "data": {
+      "text/csv": [
+       "PluginName,FunctionName,Description\n",
+       "bing,Search,\"Perform a web search.\"\n",
+       "conversation,GetConversationActionItems,\"Given a long conversation transcript, identify action items.\"\n",
+       "conversation,GetConversationTopics,\"Given a long conversation transcript, identify topics worth remembering.\"\n",
+       "conversation,SummarizeConversation,\"Given a long conversation transcript, summarize the conversation.\"\n",
+       "ConversationSummaryPlugin,funcb8580222f6c740f8ab590b8888ee6789,\"Analyze a conversation transcript and extract key topics worth remembering.\"\n",
+       "ConversationSummaryPlugin,funcbee9dfea6f634659969322ad6b640d58,\"Given a section of a conversation transcript, summarize the part of the conversation.\"\n",
+       "ConversationSummaryPlugin,funccf6d1997b53a40ab87f47a253e05fdb2,\"Given a section of a conversation transcript, identify action items.\"\n",
+       "file,Read,\"Read a file\"\n",
+       "file,Write,\"Write a file\"\n",
+       "http,Delete,\"Makes a DELETE request to a uri\"\n",
+       "http,Get,\"Makes a GET request to a uri\"\n",
+       "http,Post,\"Makes a POST request to a uri\"\n",
+       "http,Put,\"Makes a PUT request to a uri\"\n",
+       "math,Add,\"Adds an amount to a value\"\n",
+       "math,Subtract,\"Subtracts an amount from a value\"\n",
+       "text,Concat,\"Concat two strings into one.\"\n",
+       "text,Echo,\"Echo the input string. Useful for capturing plan input for use in multiple functions.\"\n",
+       "text,Length,\"Get the length of a string.\"\n",
+       "text,Lowercase,\"Convert a string to lowercase.\"\n",
+       "text,Trim,\"Trim whitespace from the start and end of a string.\"\n",
+       "text,TrimEnd,\"Trim whitespace from the end of a string.\"\n",
+       "text,TrimStart,\"Trim whitespace from the start of a string.\"\n",
+       "text,Uppercase,\"Convert a string to uppercase.\"\n",
+       "time,Date,\"Get the current date\"\n",
+       "time,DateMatchingLastDayName,\"Get the date of the last day matching the supplied week day name in English. Example: Che giorno era 'Martedi' scorso -> dateMatchingLastDayName 'Tuesday' => Tuesday, 16 May, 2023\"\n",
+       "time,Day,\"Get the current day of the month\"\n",
+       "time,DayOfWeek,\"Get the current day of the week\"\n",
+       "time,DaysAgo,\"Get the date offset by a provided number of days from today\"\n",
+       "time,Hour,\"Get the current clock hour\"\n",
+       "time,HourNumber,\"Get the current clock 24-hour number\"\n",
+       "time,Minute,\"Get the minutes on the current hour\"\n",
+       "time,Month,\"Get the current month name\"\n",
+       "time,MonthNumber,\"Get the current month number\"\n",
+       "time,Now,\"Get the current date and time in the local time zone\"\n",
+       "time,Second,\"Get the seconds on the current minute\"\n",
+       "time,Time,\"Get the current time\"\n",
+       "time,TimeZoneName,\"Get the local time zone name\"\n",
+       "time,TimeZoneOffset,\"Get the local time zone offset from UTC\"\n",
+       "time,Today,\"Get the current date\"\n",
+       "time,UtcNow,\"Get the current UTC date and time\"\n",
+       "time,Year,\"Get the current year\"\n",
+       "url,AmazonSearchUrl,\"Return URL for Amazon search query\"\n",
+       "url,BingImagesSearchUrl,\"Return URL for Bing Images search query.\"\n",
+       "url,BingMapsSearchUrl,\"Return URL for Bing Maps search query.\"\n",
+       "url,BingNewsSearchUrl,\"Return URL for Bing News search query.\"\n",
+       "url,BingSearchUrl,\"Return URL for Bing search query.\"\n",
+       "url,BingShoppingSearchUrl,\"Return URL for Bing Shopping search query.\"\n",
+       "url,BingTravelSearchUrl,\"Return URL for Bing Travel search query.\"\n",
+       "url,FacebookSearchUrl,\"Return URL for Facebook search query.\"\n",
+       "url,GitHubSearchUrl,\"Return URL for GitHub search query.\"\n",
+       "url,LinkedInSearchUrl,\"Return URL for LinkedIn search query.\"\n",
+       "url,TwitterSearchUrl,\"Return URL for Twitter search query.\"\n",
+       "url,WikipediaSearchUrl,\"Return URL for Wikipedia search query.\"\n",
+       "wait,Seconds,\"Wait a given amount of seconds\"\n",
+       "web,DownloadToFile,\"Downloads a file to local storage\"\n"
+      ],
       "text/html": [
-       "<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = Write, PluginName = file, Description = Write a file, Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>Write</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>file</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Write a file</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = path, Description = Destination file, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>path</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Destination file</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>1</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = content, Description = File content, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>content</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>File content</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>1</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = Read, PluginName = file, Description = Read a file, Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>Read</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>file</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Read a file</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = path, Description = Source file, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>path</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Source file</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>2</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = BingSearchUrl, PluginName = url, Description = Return URL for Bing search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>BingSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Bing search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>3</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = TwitterSearchUrl, PluginName = url, Description = Return URL for Twitter search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>TwitterSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Twitter search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>4</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = AmazonSearchUrl, PluginName = url, Description = Return URL for Amazon search query, Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>AmazonSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Amazon search query</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>5</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = LinkedInSearchUrl, PluginName = url, Description = Return URL for LinkedIn search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>LinkedInSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for LinkedIn search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>6</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = BingNewsSearchUrl, PluginName = url, Description = Return URL for Bing News search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>BingNewsSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Bing News search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>7</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = GitHubSearchUrl, PluginName = url, Description = Return URL for GitHub search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>GitHubSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for GitHub search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>8</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = BingImagesSearchUrl, PluginName = url, Description = Return URL for Bing Images search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>BingImagesSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Bing Images search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>9</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = BingMapsSearchUrl, PluginName = url, Description = Return URL for Bing Maps search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>BingMapsSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Bing Maps search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>10</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = FacebookSearchUrl, PluginName = url, Description = Return URL for Facebook search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>FacebookSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Facebook search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>11</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = BingShoppingSearchUrl, PluginName = url, Description = Return URL for Bing Shopping search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>BingShoppingSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Bing Shopping search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>12</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = BingTravelSearchUrl, PluginName = url, Description = Return URL for Bing Travel search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>BingTravelSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Bing Travel search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>13</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = WikipediaSearchUrl, PluginName = url, Description = Return URL for Wikipedia search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>WikipediaSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Wikipedia search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>14</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = Search, PluginName = bing, Description = Perform a web search., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>Search</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>bing</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Perform a web search.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Search query, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Search query</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>1</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = count, Description = Number of results, DefaultValue = 10, Type = , IsRequired = False }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>count</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Number of results</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre>10</pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>False</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>2</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = offset, Description = Number of results to skip, DefaultValue = 0, Type = , IsRequired = False }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>offset</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Number of results to skip</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre>0</pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>False</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>15</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = Seconds, PluginName = wait, Description = Wait a given amount of seconds, Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>Seconds</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>wait</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Wait a given amount of seconds</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = seconds, Description = The number of seconds to wait, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>seconds</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>The number of seconds to wait</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>16</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = Year, PluginName = time, Description = Get the current year, Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>Year</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>time</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Get the current year</pre></div></td></tr><tr><td>Parameters</td><td><i>(empty)</i></td></tr></tbody></table></div></details></td></tr><tr><td>17</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = Today, PluginName = time, Description = Get the current date, Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>Today</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>time</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Get the current date</pre></div></td></tr><tr><td>Parameters</td><td><i>(empty)</i></td></tr></tbody></table></div></details></td></tr><tr><td>18</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = Time, PluginName = time, Description = Get the current time, Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>Time</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>time</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Get the current time</pre></div></td></tr><tr><td>Parameters</td><td><i>(empty)</i></td></tr></tbody></table></div></details></td></tr><tr><td>19</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = UtcNow, PluginName = time, Description = Get the current UTC date and time, Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>UtcNow</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>time</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Get the current UTC date and time</pre></div></td></tr><tr><td>Parameters</td><td><i>(empty)</i></td></tr></tbody></table></div></details></td></tr><tr><td colspan=\"2\"><i>(35 more)</i></td></tr></tbody></table><style>\r\n",
+       "<table><thead><tr><td><span>PluginName</span></td><td><span>FunctionName</span></td><td><span>Description</span></td></tr></thead><tbody><tr><td>bing</td><td>Search</td><td>Perform a web search.</td></tr><tr><td>conversation</td><td>GetConversationActionItems</td><td>Given a long conversation transcript, identify action items.</td></tr><tr><td>conversation</td><td>GetConversationTopics</td><td>Given a long conversation transcript, identify topics worth remembering.</td></tr><tr><td>conversation</td><td>SummarizeConversation</td><td>Given a long conversation transcript, summarize the conversation.</td></tr><tr><td>ConversationSummaryPlugin</td><td>funcb8580222f6c740f8ab590b8888ee6789</td><td>Analyze a conversation transcript and extract key topics worth remembering.</td></tr><tr><td>ConversationSummaryPlugin</td><td>funcbee9dfea6f634659969322ad6b640d58</td><td>Given a section of a conversation transcript, summarize the part of the conversation.</td></tr><tr><td>ConversationSummaryPlugin</td><td>funccf6d1997b53a40ab87f47a253e05fdb2</td><td>Given a section of a conversation transcript, identify action items.</td></tr><tr><td>file</td><td>Read</td><td>Read a file</td></tr><tr><td>file</td><td>Write</td><td>Write a file</td></tr><tr><td>http</td><td>Delete</td><td>Makes a DELETE request to a uri</td></tr><tr><td>http</td><td>Get</td><td>Makes a GET request to a uri</td></tr><tr><td>http</td><td>Post</td><td>Makes a POST request to a uri</td></tr><tr><td>http</td><td>Put</td><td>Makes a PUT request to a uri</td></tr><tr><td>math</td><td>Add</td><td>Adds an amount to a value</td></tr><tr><td>math</td><td>Subtract</td><td>Subtracts an amount from a value</td></tr><tr><td>text</td><td>Concat</td><td>Concat two strings into one.</td></tr><tr><td>text</td><td>Echo</td><td>Echo the input string. Useful for capturing plan input for use in multiple functions.</td></tr><tr><td>text</td><td>Length</td><td>Get the length of a string.</td></tr><tr><td>text</td><td>Lowercase</td><td>Convert a string to lowercase.</td></tr><tr><td>text</td><td>Trim</td><td>Trim whitespace from the start and end of a string.</td></tr><tr><td>text</td><td>TrimEnd</td><td>Trim whitespace from the end of a string.</td></tr><tr><td>text</td><td>TrimStart</td><td>Trim whitespace from the start of a string.</td></tr><tr><td>text</td><td>Uppercase</td><td>Convert a string to uppercase.</td></tr><tr><td>time</td><td>Date</td><td>Get the current date</td></tr><tr><td>time</td><td>DateMatchingLastDayName</td><td>Get the date of the last day matching the supplied week day name in English. Example: Che giorno era &#39;Martedi&#39; scorso -&gt; dateMatchingLastDayName &#39;Tuesday&#39; =&gt; Tuesday, 16 May, 2023</td></tr><tr><td>time</td><td>Day</td><td>Get the current day of the month</td></tr><tr><td>time</td><td>DayOfWeek</td><td>Get the current day of the week</td></tr><tr><td>time</td><td>DaysAgo</td><td>Get the date offset by a provided number of days from today</td></tr><tr><td>time</td><td>Hour</td><td>Get the current clock hour</td></tr><tr><td>time</td><td>HourNumber</td><td>Get the current clock 24-hour number</td></tr><tr><td>time</td><td>Minute</td><td>Get the minutes on the current hour</td></tr><tr><td>time</td><td>Month</td><td>Get the current month name</td></tr><tr><td>time</td><td>MonthNumber</td><td>Get the current month number</td></tr><tr><td>time</td><td>Now</td><td>Get the current date and time in the local time zone</td></tr><tr><td>time</td><td>Second</td><td>Get the seconds on the current minute</td></tr><tr><td>time</td><td>Time</td><td>Get the current time</td></tr><tr><td>time</td><td>TimeZoneName</td><td>Get the local time zone name</td></tr><tr><td>time</td><td>TimeZoneOffset</td><td>Get the local time zone offset from UTC</td></tr><tr><td>time</td><td>Today</td><td>Get the current date</td></tr><tr><td>time</td><td>UtcNow</td><td>Get the current UTC date and time</td></tr><tr><td>time</td><td>Year</td><td>Get the current year</td></tr><tr><td>url</td><td>AmazonSearchUrl</td><td>Return URL for Amazon search query</td></tr><tr><td>url</td><td>BingImagesSearchUrl</td><td>Return URL for Bing Images search query.</td></tr><tr><td>url</td><td>BingMapsSearchUrl</td><td>Return URL for Bing Maps search query.</td></tr><tr><td>url</td><td>BingNewsSearchUrl</td><td>Return URL for Bing News search query.</td></tr><tr><td>url</td><td>BingSearchUrl</td><td>Return URL for Bing search query.</td></tr><tr><td>url</td><td>BingShoppingSearchUrl</td><td>Return URL for Bing Shopping search query.</td></tr><tr><td>url</td><td>BingTravelSearchUrl</td><td>Return URL for Bing Travel search query.</td></tr><tr><td>url</td><td>FacebookSearchUrl</td><td>Return URL for Facebook search query.</td></tr><tr><td>url</td><td>GitHubSearchUrl</td><td>Return URL for GitHub search query.</td></tr><tr><td>url</td><td>LinkedInSearchUrl</td><td>Return URL for LinkedIn search query.</td></tr><tr><td>url</td><td>TwitterSearchUrl</td><td>Return URL for Twitter search query.</td></tr><tr><td>url</td><td>WikipediaSearchUrl</td><td>Return URL for Wikipedia search query.</td></tr><tr><td>wait</td><td>Seconds</td><td>Wait a given amount of seconds</td></tr><tr><td>web</td><td>DownloadToFile</td><td>Downloads a file to local storage</td></tr></tbody></table><style>\r\n",
        ".dni-code-hint {\r\n",
        "    font-style: italic;\r\n",
        "    overflow: hidden;\r\n",
@@ -244,7 +322,12 @@
     }
    ],
    "source": [
-    "kernel.Functions.GetFunctionViews().Display();"
+    "Microsoft.DotNet.Interactive.Formatting.Formatter.ListExpansionLimit = 100;\n",
+    "kernel.Functions.GetFunctionViews()\n",
+    "    .Select(fv => new { fv.PluginName, FunctionName=fv.Name, fv.Description })  \n",
+    "    .OrderBy(fv => fv.PluginName)\n",
+    "    .ThenBy(fv => fv.FunctionName)      \n",
+    "    .DisplayTable<dynamic>();"
    ]
   },
   {
@@ -270,37 +353,39 @@
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The sky appears blue because of a process called Rayleigh scattering. As sunlight reaches Earth's\n",
-      "atmosphere, it is made up of different colors, which travel as waves of different lengths. Blue and\n",
-      "violet light have the shortest wavelengths and are scattered in all directions by the oxygen and\n",
-      "nitrogen molecules in Earth's atmosphere. This scattered blue and violet light reaches our eyes from\n",
-      "all directions, making the sky appear blue.\n",
-      "\n",
-      "You might wonder why we don't see a violet sky, given\n",
-      "that violet light is scattered more than\n",
-      "\n",
-      "The color of the ocean can vary and is influenced by several factors. The green color in the ocean\n",
-      "is usually due to the presence of large amounts of algae or phytoplankton, tiny plant-like organisms\n",
-      "that live in the water and can photosynthesize. These organisms contain chlorophyll, a green pigment\n",
-      "used in photosynthesis, which gives the water a greenish hue when present in large quantities.\n",
-      "Additionally, the color of the ocean can be affected by the amount and angle of sunlight, the\n",
-      "\n"
-     ]
+     "data": {
+      "text/html": [
+       "<p style=\"color:#a0d2eb;background-color:#8458B3;padding:10px;border-radius:5px;\">The sky appears blue because of a process called Rayleigh scattering. As sunlight reaches Earth&#39;s atmosphere, it is made up of different colors, which are seen as different wavelengths. Shorter wavelengths (like blue and violet) are scattered in all directions more than other colors like red, yellow, and green, which have longer wavelengths.</p>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<p style=\"color:#a0d2eb;background-color:#8458B3;padding:10px;border-radius:5px;\">The color of the ocean can range from deep blue to green, depending on various factors. The primary reason for the ocean appearing green is the presence of algae and other plant life. When sunlight penetrates the ocean surface, it can cause photosynthesis in these plants, leading to a bloom of algae and phytoplankton, which can give the ocean a greenish hue.</p>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
     "using Microsoft.SemanticKernel.Connectors.AI.OpenAI;\n",
-    "\n",
+    "using  Microsoft.DotNet.Interactive.Formatting;\n",
     "// 1. define the function called \"ask\"\n",
     "var askFunction = kernel.CreateSemanticFunction(\n",
     "    promptTemplate: \"{{$input}}\", \n",
     "    requestSettings: new OpenAIRequestSettings() { \n",
-    "        MaxTokens = 100, \n",
-    "        Temperature = 0.4, \n",
-    "        TopP = 1,\n",
+    "        // The maximum number of tokens to generate in the completion.\n",
+    "        MaxTokens = 100,    \n",
+    "        // Temperature controls the randomness of the completion. The higher the temperature, the more random the completion.\n",
+    "        Temperature = 0.5,  \n",
+    "        // TopP controls the diversity of the completion. The higher the TopP, the more diverse the completion.\n",
+    "        TopP = 0.5,           \n",
+    "        // One or more sequences where the API will stop generating further tokens.\n",
+    "        StopSequences = new string[] { \"\\n\" }, \n",
     "        // Here I have specified the service id. \n",
     "        // Comment this out if you would like to use the default service id.\n",
     "        // ServiceId = \"oai-gpt-4-0613\" \n",
@@ -308,13 +393,13 @@
     "    functionName: \"ask\");\n",
     "\n",
     "// 2. call the function directly using the function object\n",
-    "var directResult = await kernel.RunAsync(\"Why is the sky blue?\", askFunction);\n",
-    "Utils.Print(directResult.GetValue<string>());\n",
+    "KernelHelper.Print(await kernel\n",
+    "    .RunAsync(@\"Why is the sky blue?\", askFunction));\n",
     "\n",
     "// ALTERNATIVELY\n",
     "// 2. call the function by name using the kernel.\n",
-    "var nameResult = await kernel.Functions.GetFunction(\"ask\").InvokeAsync(\"why is the ocean green?\", kernel);\n",
-    "Utils.Print(nameResult.GetValue<string>());"
+    "KernelHelper.Print(await kernel\n",
+    "    .Functions.GetFunction(\"ask\").InvokeAsync(@\"why is the ocean green?\", kernel));"
    ]
   },
   {
@@ -348,8 +433,8 @@
    "outputs": [
     {
      "data": {
-      "text/plain": [
-       "hello world"
+      "text/html": [
+       "<div style=\"color:#a0d2eb;background-color:#8458B3;padding:10px;border-radius:5px;font-family: monospace;\"><span style=\"white-space:pre;color:black!important;background-color:#a0d2eb!important\">hello world</span></div>"
       ]
      },
      "metadata": {},
@@ -357,8 +442,17 @@
     },
     {
      "data": {
-      "text/plain": [
-       "  hello world"
+      "text/html": [
+       "<div style=\"color:#a0d2eb;background-color:#8458B3;padding:10px;border-radius:5px;font-family: monospace;\"><span style=\"white-space:pre;color:black!important;background-color:#a0d2eb!important\">hello world  </span></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div style=\"color:#a0d2eb;background-color:#8458B3;padding:10px;border-radius:5px;font-family: monospace;\"><span style=\"white-space:pre;color:black!important;background-color:#a0d2eb!important\">  hello world</span></div>"
       ]
      },
      "metadata": {},
@@ -366,11 +460,26 @@
     }
    ],
    "source": [
-    "var r = await kernel.Functions.GetFunction(\"text\", \"trim\").InvokeAsync(\"  hello world  \", kernel);\n",
-    "r.GetValue<string>().Display();\n",
+    "// Trim\n",
+    "KernelHelper.Print(await kernel\n",
+    "    .Functions\n",
+    "    .GetFunction(\"text\", \"trim\")\n",
+    "    .InvokeAsync(\"  hello world  \", kernel)\n",
+    ", PrintElement.Pre);\n",
     "\n",
-    "r = await kernel.Functions.GetFunction(\"text\", \"trimEnd\").InvokeAsync(\"  hello world  \", kernel);\n",
-    "r.GetValue<string>().Display();"
+    "// Trim Start\n",
+    "KernelHelper.Print(await kernel\n",
+    "    .Functions\n",
+    "    .GetFunction(\"text\", \"trimStart\")\n",
+    "    .InvokeAsync(\"  hello world  \", kernel)\n",
+    ", PrintElement.Pre);\n",
+    "\n",
+    "// Trim End\n",
+    "KernelHelper.Print(await kernel\n",
+    "    .Functions\n",
+    "    .GetFunction(\"text\", \"trimEnd\")\n",
+    "    .InvokeAsync(\"  hello world  \", kernel)\n",
+    ", PrintElement.Pre);"
    ]
   },
   {
@@ -396,21 +505,23 @@
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "WHY DON'T SCIENTISTS TRUST ATOMS? BECAUSE THEY MAKE UP EVERYTHING!\n",
-      "\n"
-     ]
+     "data": {
+      "text/html": [
+       "<p style=\"color:#a0d2eb;background-color:#8458B3;padding:10px;border-radius:5px;\">WHY DON&#39;T SCIENTISTS TRUST ATOMS? BECAUSE THEY MAKE UP EVERYTHING!</p>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "var r = await kernel.RunAsync(\n",
-    "    \"Tell me 1 sentence joke.\",\n",
+    "// Here we demonstrate chaining functions together\n",
+    "// First we ask the question using the ask function (which we wrote earlier),\n",
+    "// then we uppercase the response using the text.uppercase function (part of the core plugins).\n",
+    "KernelHelper.Print(await kernel.RunAsync(\n",
+    "    @\"Tell me 1 sentence joke.\",\n",
     "    kernel.Functions.GetFunction(\"ask\"),\n",
-    "    kernel.Functions.GetFunction(\"text\", \"uppercase\")\n",
-    ");\n",
-    "Utils.Print(r.GetValue<string>());"
+    "    kernel.Functions.GetFunction(\"text\", \"uppercase\")));"
    ]
   },
   {
@@ -418,6 +529,47 @@
    "metadata": {},
    "source": [
     "## Step 5: Test Web Plugins"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "vscode": {
+     "languageId": "polyglot-notebook"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<p style=\"color:#a0d2eb;background-color:#8458B3;padding:10px;border-radius:5px;\">The content discusses the annual inflation rates in Australia from 1950, with a focus on recent data up to September 2023. The Consumer Price Index (CPI) in Australia rose by 1.2% in the third quarter of 2023. This inflation rebound was driven by surging fuel prices and has implications for Australians with mortgages. The economy has shown resilience despite a significant increase in interest rates, marking the second steepest monetary policy tightening cycle in the bank&#39;s history. However, it&#39;s noted that consumers are cutting back in response. There&#39;s also a prediction that interest rates are likely to rise further. The highest inflation rate month-over-month (MoM) in Australia was 7.55% in the fourth quarter of 1951, and the lowest was -1.90% in the second quarter of 2020.</p>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Here we use the bing plugin (part of the web plugins) to search the web for the query \"What is the inflation rate in the US in November 2023?\"\n",
+    "// In addition we use funcion chaining to summarize the conversation. (part of the core plugins).\n",
+    "KernelHelper.Print(await kernel.RunAsync(\n",
+    "    @\"What is the inflation rate in the Australia in November 2023?\",\n",
+    "    kernel.Functions.GetFunction(\"bing\", \"search\"),\n",
+    "    kernel.Functions.GetFunction(\"conversation\", \"SummarizeConversation\")));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 6: Test Memories"
    ]
   },
   {
@@ -436,40 +588,70 @@
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The annual inflation rate in the United States was 3.7% for the 12 months ending in September,\n",
-      "according to data from the U.S. Labor Department. This rate was consistent with the previous period.\n",
-      "The Federal Reserve has left interest rates unchanged, marking the second consecutive meeting where\n",
-      "rates were held steady. This follows a series of 11 rate hikes, including four in 2023. Despite the\n",
-      "steady rates, the Federal Reserve has signaled that future rate hikes are possible to curb\n",
-      "persistent inflation. The annual inflation rate has risen from 3.2% in 2011 to 8.3% in 2022,\n",
-      "indicating a weakening in the purchasing power of the U.S. dollar. The inflation rate for core goods\n",
-      "and services was below the Federal Reserve's target prior to the pandemic, averaging 1.7% annually\n",
-      "between 2016 and 2019, but jumped to 5.2% in 2021 and 4.9% in 2022. The Consumer Price Index (CPI),\n",
-      "a measure of the average change over time in prices paid by urban consumers for a market basket of\n",
-      "consumer goods and services, is used to track these changes.\n",
-      "\n"
-     ]
+     "data": {
+      "text/html": [
+       "<pre>Saved 3 items to the random-animals collection.</pre>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<p style=\"color:#a0d2eb;background-color:#8458B3;padding:10px;border-radius:5px;\">Has tentacles? - Octopus</p>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre>Deleted 3 items from the random-animals collection.</pre>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "var webQuery = \"What is the inflation rate in the US in November 2023?\";\n",
+    "var db = \"random-animals\";\n",
+    "var ids = new List<string>();\n",
     "\n",
-    "var r = await kernel.RunAsync(\n",
-    "    webQuery,\n",
-    "    kernel.Functions.GetFunction(\"bing\", \"search\"),\n",
-    "    kernel.Functions.GetFunction(\"conversation\", \"SummarizeConversation\")\n",
+    "// Save some information to the database\n",
+    "ids.Add(await KernelHelper.SaveChunkAsync(\n",
+    "    kernel: kernel, db: db, text: \"Dog\"));\n",
+    "ids.Add(await KernelHelper.SaveChunkAsync(\n",
+    "    kernel: kernel, db: db, text: \"Elephant\"));\n",
+    "ids.Add(await KernelHelper.SaveChunkAsync(\n",
+    "    kernel: kernel, db: db, text: \"Octopus\"));\n",
+    "KernelHelper.Info($\"Saved {ids.Count} items to the {db} collection.\");\n",
+    "\n",
+    "// Search the database\n",
+    "var query = @\"Has tentacles?\";\n",
+    "var rs = await KernelHelper.SearchDatabaseAsync(\n",
+    "    kernel: kernel, \n",
+    "    db: db, \n",
+    "    q: query, \n",
+    "    limit: 1, \n",
+    "    minRelevanceScore: 0.5\n",
     ");\n",
-    "Utils.Print(r.GetValue<string>());"
+    "KernelHelper.Print($\"{query} - {rs.FirstOrDefault()?.Text}\");\n",
+    "\n",
+    "// Cleanup the database\n",
+    "var cleanup = await KernelHelper.DeleteChunkAsync(\n",
+    "    kernel: kernel, \n",
+    "    db: db, \n",
+    "    ids: ids);\n",
+    "KernelHelper.Info($\"Deleted {cleanup.Count} items from the {db} collection.\");"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Step 6: Test Memories"
+    "Alternatively, chunk and store a whole book!"
    ]
   },
   {
@@ -491,41 +673,124 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Has tentacles? - Elephant\n",
-      "\n"
+      "- Saved chunk 0.\n",
+      "- Saved chunk 1.\n",
+      "- Saved chunk 2.\n",
+      "- Saved chunk 3.\n",
+      "- Saved chunk 4.\n",
+      "- Saved chunk 5.\n",
+      "- Saved chunk 6.\n",
+      "- Saved chunk 7.\n",
+      "- Saved chunk 8.\n",
+      "- Saved chunk 9.\n",
+      "- Saved chunk 10.\n",
+      "- Saved chunk 11.\n",
+      "- Saved chunk 12.\n",
+      "- Saved chunk 13.\n",
+      "- Saved chunk 14.\n",
+      "- Saved chunk 15.\n",
+      "- Saved chunk 16.\n",
+      "- Saved chunk 17.\n",
+      "- Saved chunk 18.\n",
+      "- Saved chunk 19.\n",
+      "- Saved chunk 20.\n",
+      "- Saved chunk 21.\n",
+      "- Saved chunk 22.\n",
+      "- Saved chunk 23.\n",
+      "- Saved chunk 24.\n",
+      "- Saved chunk 25.\n",
+      "- Saved chunk 26.\n",
+      "- Saved chunk 27.\n",
+      "- Saved chunk 28.\n",
+      "- Saved chunk 29.\n",
+      "- Saved chunk 30.\n",
+      "- Saved chunk 31.\n",
+      "- Saved chunk 32.\n",
+      "- Saved chunk 33.\n",
+      "- Saved chunk 34.\n",
+      "- Saved chunk 35.\n",
+      "- Saved chunk 36.\n",
+      "- Saved chunk 37.\n",
+      "- Saved chunk 38.\n",
+      "- Saved chunk 39.\n",
+      "- Saved chunk 40.\n",
+      "- Saved chunk 41.\n",
+      "- Saved chunk 42.\n",
+      "- Saved chunk 43.\n",
+      "- Saved chunk 44.\n",
+      "- Saved chunk 45.\n"
      ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre>Saved 46 items to the intelligent-investor collection.</pre>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "var db = \"random-animals\";\n",
-    "\n",
-    "await kernel.Memory.SaveInformationAsync(\n",
-    "    db, id: \"1\", text: \"Dog\");\n",
-    "await kernel.Memory.SaveInformationAsync(\n",
-    "    db, id: \"2\", text: \"Elephant\");\n",
-    "await kernel.Memory.SaveInformationAsync(\n",
-    "    db, id: \"3\", text: \"Octopus\");\n",
-    "\n",
-    "var memorySearch = \"Has tentacles?\";\n",
-    "await foreach (var item in kernel.Memory.SearchAsync(\n",
-    "    collection: db, \n",
-    "    query: memorySearch, \n",
-    "    limit: 1, \n",
-    "    minRelevanceScore: 0.5))\n",
-    "{\n",
-    "    Utils.Print($\"{memorySearch} - {item.Metadata.Text}\");\n",
-    "}\n",
-    "\n",
-    "await kernel.Memory.RemoveAsync(db,\"1\");\n",
-    "await kernel.Memory.RemoveAsync(db,\"2\");\n",
-    "await kernel.Memory.RemoveAsync(db,\"3\");"
+    "// Read file & convert it into smaller chunks\n",
+    "var db = \"intelligent-investor\";\n",
+    "var ids = await KernelHelper.SaveFileAsync(\n",
+    "    kernel: kernel, \n",
+    "    db: db, \n",
+    "    path: \"../../../data/intelligent-investor.txt\");\n",
+    "KernelHelper.Info($\"Saved {ids.Count} items to the {db} collection.\");"
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "vscode": {
+     "languageId": "polyglot-notebook"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<p style=\"color:#a0d2eb;background-color:#8458B3;padding:10px;border-radius:5px;;font-weight:bolder;text-decoration:underline;\">Ben Graham&#39;s investment philosophy?</p>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<p style=\"color:#a0d2eb;background-color:#8458B3;padding:10px;border-radius:5px;\">Ben Graham&#39;s investment philosophy emphasizes the dangers of projection due to the uncertainty of the future, including factors like inflation, economic recessions, pandemics, and geopolitical upheavals. He believes that trying to time the market is a futile effort for an ordinary investor. Instead, Graham advocates for a protection-based approach that doesn&#39;t attempt to time the market. He suggests that value investors should focus on identifying and investing in large, conservatively financed companies whose present value, estimated by tangible assets, is significantly lower than their current stock prices. His book, &quot;The Intelligent Investor,&quot; provides guidance on developing the mindset necessary to avoid panic during market fluctuations. Graham also differentiates between two types of investors: defensive investors, who aim to protect their capital, generate decent returns, and minimize frequent decisions, and enterprising investors, who actively manage their portfolios, investing more time in stock selection without necessarily taking on more risk.</p>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "Alternatively, chunk and store a whole book!"
+    "// Search the database\n",
+    "var query = @\"Ben Graham's investment philosophy?\";\n",
+    "KernelHelper.Print(query, PrintElement.Header);\n",
+    "var rs = await KernelHelper.SearchDatabaseAsync(\n",
+    "    kernel: kernel, \n",
+    "    db: db, \n",
+    "    q: query, \n",
+    "    limit: 2, \n",
+    "    minRelevanceScore: 0.5\n",
+    ");\n",
+    "rs.ForEach(r => query += $\"\\n\\n{r.Text}\");\n",
+    "//KernelHelper.Print($\"{query} \\n {rs.FirstOrDefault()?.Text}\");\n",
+    "KernelHelper.Print(await kernel.RunAsync(\n",
+    "    query,\n",
+    "    kernel.Functions.GetFunction(\"conversation\", \"SummarizeConversation\")));"
    ]
   },
   {
@@ -544,79 +809,22 @@
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Chunks: 46\n",
-      "Chunk 0 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 1 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 2 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 3 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 4 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 5 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 6 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 7 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 8 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 9 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 10 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 11 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 12 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 13 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 14 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 15 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 16 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 17 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 18 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 19 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 20 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 21 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 22 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 23 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 24 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 25 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 26 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 27 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 28 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 29 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 30 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 31 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 32 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 33 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 34 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 35 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 36 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 37 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 38 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 39 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 40 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 41 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 42 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 43 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 44 of 46 saved to memory collection intelligent-investor\n",
-      "Chunk 45 of 46 saved to memory collection intelligent-investor\n"
-     ]
+     "data": {
+      "text/html": [
+       "<pre>Deleted 46 items from the intelligent-investor collection.</pre>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "// Read file & convert it into smaller chunks\n",
-    "var chunks = await KernelHelper.GetChunksAsync(\"../../../data/intelligent-investor.txt\");\n",
-    "Console.WriteLine($\"Chunks: {chunks.Count()}\");\n",
-    "\n",
-    "var db = \"intelligent-investor\";\n",
-    "// Save chunks into memory\n",
-    "for (var i = 0; i < chunks.Count(); i++)\n",
-    "{\n",
-    "    var chunk = chunks[i];        \n",
-    "    await kernel.Memory.SaveInformationAsync(\n",
-    "        collection: db,                     // Collection where to save the information.\n",
-    "        text: chunk,                        // Information to save.\n",
-    "        id: $\"{db}-{i}\",                    // Unique identifier.\n",
-    "        description: $\"d:{db} c:{i}\",       // Optional description.\n",
-    "        additionalMetadata: i.ToString()    // Optional string for saving custom metadata.\n",
-    "    );\n",
-    "\n",
-    "    Console.WriteLine($\"Chunk {i} of {chunks.Count} saved to memory collection {db}\");\n",
-    "}"
+    "// Cleanup the database\n",
+    "var cleanup = await KernelHelper.DeleteChunkAsync(\n",
+    "    kernel: kernel, \n",
+    "    db: db, \n",
+    "    ids: ids);\n",
+    "KernelHelper.Info($\"Deleted {cleanup.Count} items from the {db} collection.\");"
    ]
   }
  ],

--- a/notebooks/dotnet/sample/sample-notebook.ipynb
+++ b/notebooks/dotnet/sample/sample-notebook.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 1,
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -44,7 +44,7 @@
     "#r \"nuget: Microsoft.SemanticKernel.Plugins.Core, 1.0.0-beta4\"\n",
     "#r \"nuget: Microsoft.SemanticKernel.Plugins.Web, 1.0.0-beta4\"\n",
     "#r \"nuget: Microsoft.SemanticKernel.Plugins.Memory, 1.0.0-beta4\"\n",
-    "#r \"nuget: Microsoft.SemanticKernel.Connectors.Memory.AzureCognitiveSearch, 1.0.0-beta4\"\n"
+    "#r \"nuget: Microsoft.SemanticKernel.Connectors.Memory.AzureCognitiveSearch, 1.0.0-beta4\""
    ]
   },
   {
@@ -63,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 2,
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -77,6 +77,7 @@
    },
    "outputs": [],
    "source": [
+    "#!import ../../../config/dotnet/StringHelpers.cs\n",
     "#!import ../../../config/dotnet/ConfigModels.cs\n",
     "#!import ../../../config/dotnet/ConfigHelper.cs\n",
     "#!import ../../../config/dotnet/KernelHelper.cs"
@@ -92,7 +93,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 3,
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -120,7 +121,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 4,
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -176,7 +177,7 @@
    ],
    "source": [
     "var kernel = KernelHelper.LoadKernel();\n",
-    "kernel.Display();\n"
+    "kernel.Display();"
    ]
   },
   {
@@ -188,7 +189,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 5,
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -204,7 +205,7 @@
     {
      "data": {
       "text/html": [
-       "<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = GitHubSearchUrl, PluginName = url, Description = Return URL for GitHub search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>GitHubSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for GitHub search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>1</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = WikipediaSearchUrl, PluginName = url, Description = Return URL for Wikipedia search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>WikipediaSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Wikipedia search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>2</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = BingShoppingSearchUrl, PluginName = url, Description = Return URL for Bing Shopping search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>BingShoppingSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Bing Shopping search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>3</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = BingImagesSearchUrl, PluginName = url, Description = Return URL for Bing Images search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>BingImagesSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Bing Images search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>4</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = FacebookSearchUrl, PluginName = url, Description = Return URL for Facebook search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>FacebookSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Facebook search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>5</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = BingSearchUrl, PluginName = url, Description = Return URL for Bing search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>BingSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Bing search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>6</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = BingNewsSearchUrl, PluginName = url, Description = Return URL for Bing News search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>BingNewsSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Bing News search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>7</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = LinkedInSearchUrl, PluginName = url, Description = Return URL for LinkedIn search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>LinkedInSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for LinkedIn search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>8</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = AmazonSearchUrl, PluginName = url, Description = Return URL for Amazon search query, Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>AmazonSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Amazon search query</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>9</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = BingMapsSearchUrl, PluginName = url, Description = Return URL for Bing Maps search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>BingMapsSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Bing Maps search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>10</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = TwitterSearchUrl, PluginName = url, Description = Return URL for Twitter search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>TwitterSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Twitter search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>11</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = BingTravelSearchUrl, PluginName = url, Description = Return URL for Bing Travel search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>BingTravelSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Bing Travel search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>12</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = Seconds, PluginName = wait, Description = Wait a given amount of seconds, Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>Seconds</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>wait</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Wait a given amount of seconds</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = seconds, Description = The number of seconds to wait, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>seconds</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>The number of seconds to wait</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>13</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = Trim, PluginName = text, Description = Trim whitespace from the start and end of a string., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>Trim</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>text</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Trim whitespace from the start and end of a string.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = input, Description = , DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>input</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>14</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = Echo, PluginName = text, Description = Echo the input string. Useful for capturing plan input for use in multiple functions., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>Echo</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>text</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Echo the input string. Useful for capturing plan input for use in multiple functions.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = text, Description = Input string to echo., DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>text</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Input string to echo.</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>15</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = Concat, PluginName = text, Description = Concat two strings into one., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>Concat</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>text</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Concat two strings into one.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = input, Description = First input to concatenate with, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>input</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>First input to concatenate with</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>1</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = input2, Description = Second input to concatenate with, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>input2</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Second input to concatenate with</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>16</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = Uppercase, PluginName = text, Description = Convert a string to uppercase., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>Uppercase</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>text</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Convert a string to uppercase.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = input, Description = , DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>input</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>17</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = Lowercase, PluginName = text, Description = Convert a string to lowercase., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>Lowercase</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>text</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Convert a string to lowercase.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = input, Description = , DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>input</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>18</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = TrimStart, PluginName = text, Description = Trim whitespace from the start of a string., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>TrimStart</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>text</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Trim whitespace from the start of a string.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = input, Description = , DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>input</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>19</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = Length, PluginName = text, Description = Get the length of a string., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>Length</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>text</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Get the length of a string.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = input, Description = , DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>input</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td colspan=\"2\"><i>(29 more)</i></td></tr></tbody></table><style>\r\n",
+       "<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = Write, PluginName = file, Description = Write a file, Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>Write</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>file</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Write a file</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = path, Description = Destination file, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>path</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Destination file</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>1</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = content, Description = File content, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>content</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>File content</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>1</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = Read, PluginName = file, Description = Read a file, Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>Read</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>file</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Read a file</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = path, Description = Source file, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>path</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Source file</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>2</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = BingSearchUrl, PluginName = url, Description = Return URL for Bing search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>BingSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Bing search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>3</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = TwitterSearchUrl, PluginName = url, Description = Return URL for Twitter search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>TwitterSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Twitter search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>4</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = AmazonSearchUrl, PluginName = url, Description = Return URL for Amazon search query, Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>AmazonSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Amazon search query</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>5</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = LinkedInSearchUrl, PluginName = url, Description = Return URL for LinkedIn search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>LinkedInSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for LinkedIn search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>6</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = BingNewsSearchUrl, PluginName = url, Description = Return URL for Bing News search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>BingNewsSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Bing News search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>7</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = GitHubSearchUrl, PluginName = url, Description = Return URL for GitHub search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>GitHubSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for GitHub search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>8</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = BingImagesSearchUrl, PluginName = url, Description = Return URL for Bing Images search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>BingImagesSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Bing Images search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>9</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = BingMapsSearchUrl, PluginName = url, Description = Return URL for Bing Maps search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>BingMapsSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Bing Maps search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>10</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = FacebookSearchUrl, PluginName = url, Description = Return URL for Facebook search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>FacebookSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Facebook search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>11</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = BingShoppingSearchUrl, PluginName = url, Description = Return URL for Bing Shopping search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>BingShoppingSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Bing Shopping search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>12</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = BingTravelSearchUrl, PluginName = url, Description = Return URL for Bing Travel search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>BingTravelSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Bing Travel search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>13</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = WikipediaSearchUrl, PluginName = url, Description = Return URL for Wikipedia search query., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>WikipediaSearchUrl</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>url</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Return URL for Wikipedia search query.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Text to search for, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Text to search for</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>14</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = Search, PluginName = bing, Description = Perform a web search., Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>Search</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>bing</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Perform a web search.</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = query, Description = Search query, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>query</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Search query</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>1</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = count, Description = Number of results, DefaultValue = 10, Type = , IsRequired = False }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>count</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Number of results</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre>10</pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>False</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>2</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = offset, Description = Number of results to skip, DefaultValue = 0, Type = , IsRequired = False }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>offset</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Number of results to skip</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre>0</pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>False</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>15</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = Seconds, PluginName = wait, Description = Wait a given amount of seconds, Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>Seconds</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>wait</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Wait a given amount of seconds</pre></div></td></tr><tr><td>Parameters</td><td><table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>ParameterView { Name = seconds, Description = The number of seconds to wait, DefaultValue = , Type = , IsRequired = True }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>seconds</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>The number of seconds to wait</pre></div></td></tr><tr><td>DefaultValue</td><td><div class=\"dni-plaintext\"><pre></pre></div></td></tr><tr><td>Type</td><td><div class=\"dni-plaintext\"><pre>&lt;null&gt;</pre></div></td></tr><tr><td>IsRequired</td><td><div class=\"dni-plaintext\"><pre>True</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table></td></tr></tbody></table></div></details></td></tr><tr><td>16</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = Year, PluginName = time, Description = Get the current year, Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>Year</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>time</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Get the current year</pre></div></td></tr><tr><td>Parameters</td><td><i>(empty)</i></td></tr></tbody></table></div></details></td></tr><tr><td>17</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = Today, PluginName = time, Description = Get the current date, Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>Today</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>time</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Get the current date</pre></div></td></tr><tr><td>Parameters</td><td><i>(empty)</i></td></tr></tbody></table></div></details></td></tr><tr><td>18</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = Time, PluginName = time, Description = Get the current time, Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>Time</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>time</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Get the current time</pre></div></td></tr><tr><td>Parameters</td><td><i>(empty)</i></td></tr></tbody></table></div></details></td></tr><tr><td>19</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>FunctionView { Name = UtcNow, PluginName = time, Description = Get the current UTC date and time, Parameters = Microsoft.SemanticKernel.ParameterView[] }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Name</td><td><div class=\"dni-plaintext\"><pre>UtcNow</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>time</pre></div></td></tr><tr><td>Description</td><td><div class=\"dni-plaintext\"><pre>Get the current UTC date and time</pre></div></td></tr><tr><td>Parameters</td><td><i>(empty)</i></td></tr></tbody></table></div></details></td></tr><tr><td colspan=\"2\"><i>(35 more)</i></td></tr></tbody></table><style>\r\n",
        ".dni-code-hint {\r\n",
        "    font-style: italic;\r\n",
        "    overflow: hidden;\r\n",
@@ -255,7 +256,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 7,
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -269,24 +270,25 @@
    },
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "The sky appears blue because of a process called Rayleigh scattering. As sunlight reaches Earth's atmosphere, it is made up of different colors that are represented in a rainbow, or light spectrum. These colors are differentiated by their wavelengths. Blue and violet light have the shortest wavelengths and are scattered in all directions by the gas molecules in Earth's atmosphere.\n",
-       "\n",
-       "Blue light is scattered more than other colors because it travels in smaller, shorter waves. This scattering causes the sky to appear blue in our perception. However,"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "The color of the ocean can vary and is influenced by several factors. It can appear green due to the presence of large amounts of algae or phytoplankton, tiny plant-like organisms that contain chlorophyll. When sunlight hits the water, it can be absorbed or reflected. Chlorophyll in phytoplankton absorbs light, particularly in the red and blue parts of the light spectrum, and reflects green light. This reflected light is what we see, which can give the ocean a green appearance"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The sky appears blue because of a process called Rayleigh scattering. As sunlight reaches Earth's\n",
+      "atmosphere, it is made up of different colors, which travel as waves of different lengths. Blue and\n",
+      "violet light have the shortest wavelengths and are scattered in all directions by the oxygen and\n",
+      "nitrogen molecules in Earth's atmosphere. This scattered blue and violet light reaches our eyes from\n",
+      "all directions, making the sky appear blue.\n",
+      "\n",
+      "You might wonder why we don't see a violet sky, given\n",
+      "that violet light is scattered more than\n",
+      "\n",
+      "The color of the ocean can vary and is influenced by several factors. The green color in the ocean\n",
+      "is usually due to the presence of large amounts of algae or phytoplankton, tiny plant-like organisms\n",
+      "that live in the water and can photosynthesize. These organisms contain chlorophyll, a green pigment\n",
+      "used in photosynthesis, which gives the water a greenish hue when present in large quantities.\n",
+      "Additionally, the color of the ocean can be affected by the amount and angle of sunlight, the\n",
+      "\n"
+     ]
     }
    ],
    "source": [
@@ -307,12 +309,12 @@
     "\n",
     "// 2. call the function directly using the function object\n",
     "var directResult = await kernel.RunAsync(\"Why is the sky blue?\", askFunction);\n",
-    "directResult.GetValue<string>().Display();\n",
+    "Utils.Print(directResult.GetValue<string>());\n",
     "\n",
     "// ALTERNATIVELY\n",
     "// 2. call the function by name using the kernel.\n",
     "var nameResult = await kernel.Functions.GetFunction(\"ask\").InvokeAsync(\"why is the ocean green?\", kernel);\n",
-    "nameResult.GetValue<string>().Display();\n"
+    "Utils.Print(nameResult.GetValue<string>());"
    ]
   },
   {
@@ -331,7 +333,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 8,
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -380,119 +382,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {
-    "dotnet_interactive": {
-     "language": "csharp"
-    },
-    "polyglot_notebook": {
-     "kernelName": "csharp"
-    },
-    "vscode": {
-     "languageId": "polyglot-notebook"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "WHY DON'T SCIENTISTS TRUST ATOMS? BECAUSE THEY MAKE UP EVERYTHING!"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "var r = await kernel.RunAsync(\n",
-    "    \"Tell me 1 sentence joke.\",\n",
-    "    kernel.Functions.GetFunction(\"ask\"),\n",
-    "    kernel.Functions.GetFunction(\"text\", \"uppercase\")\n",
-    ");\n",
-    "r.GetValue<string>().Display();"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Step 5: Test Web Plugins"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {
-    "dotnet_interactive": {
-     "language": "csharp"
-    },
-    "polyglot_notebook": {
-     "kernelName": "csharp"
-    },
-    "vscode": {
-     "languageId": "polyglot-notebook"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<details open=\"open\" class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[&quot;The annual inflation rate for the United States was 3.7% for the 12 months ended September, according to U.S. Labor Department data published on Oct. 12, 2023. This was the same as the 3.7% in the previous period. The next update on inflation is scheduled for release on Nov. 14 at 8:30 a.m. ET.&quot;,&quot;...</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>FunctionName</td><td><div class=\"dni-plaintext\"><pre>Search</pre></div></td></tr><tr><td>PluginName</td><td><div class=\"dni-plaintext\"><pre>bing</pre></div></td></tr><tr><td>Metadata</td><td><i>(empty)</i></td></tr></tbody></table></div></details><style>\r\n",
-       ".dni-code-hint {\r\n",
-       "    font-style: italic;\r\n",
-       "    overflow: hidden;\r\n",
-       "    white-space: nowrap;\r\n",
-       "}\r\n",
-       ".dni-treeview {\r\n",
-       "    white-space: nowrap;\r\n",
-       "}\r\n",
-       ".dni-treeview td {\r\n",
-       "    vertical-align: top;\r\n",
-       "    text-align: start;\r\n",
-       "}\r\n",
-       "details.dni-treeview {\r\n",
-       "    padding-left: 1em;\r\n",
-       "}\r\n",
-       "table td {\r\n",
-       "    text-align: start;\r\n",
-       "}\r\n",
-       "table tr { \r\n",
-       "    vertical-align: top; \r\n",
-       "    margin: 0em 0px;\r\n",
-       "}\r\n",
-       "table tr td pre \r\n",
-       "{ \r\n",
-       "    vertical-align: top !important; \r\n",
-       "    margin: 0em 0px !important;\r\n",
-       "} \r\n",
-       "table th {\r\n",
-       "    text-align: start;\r\n",
-       "}\r\n",
-       "</style>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "var webQuery = \"What is the inflation rate in the US in September 2023?\";\n",
-    "\n",
-    "var inflationData = await kernel.Functions.GetFunction(\"bing\", \"search\").InvokeAsync(webQuery, kernel);\n",
-    "\n",
-    "inflationData.Display();"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Step 6: Test Memories"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 9,
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -509,7 +399,100 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Has tentacles? - Octopus\n"
+      "WHY DON'T SCIENTISTS TRUST ATOMS? BECAUSE THEY MAKE UP EVERYTHING!\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "var r = await kernel.RunAsync(\n",
+    "    \"Tell me 1 sentence joke.\",\n",
+    "    kernel.Functions.GetFunction(\"ask\"),\n",
+    "    kernel.Functions.GetFunction(\"text\", \"uppercase\")\n",
+    ");\n",
+    "Utils.Print(r.GetValue<string>());"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 5: Test Web Plugins"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "vscode": {
+     "languageId": "polyglot-notebook"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The annual inflation rate in the United States was 3.7% for the 12 months ending in September,\n",
+      "according to data from the U.S. Labor Department. This rate was consistent with the previous period.\n",
+      "The Federal Reserve has left interest rates unchanged, marking the second consecutive meeting where\n",
+      "rates were held steady. This follows a series of 11 rate hikes, including four in 2023. Despite the\n",
+      "steady rates, the Federal Reserve has signaled that future rate hikes are possible to curb\n",
+      "persistent inflation. The annual inflation rate has risen from 3.2% in 2011 to 8.3% in 2022,\n",
+      "indicating a weakening in the purchasing power of the U.S. dollar. The inflation rate for core goods\n",
+      "and services was below the Federal Reserve's target prior to the pandemic, averaging 1.7% annually\n",
+      "between 2016 and 2019, but jumped to 5.2% in 2021 and 4.9% in 2022. The Consumer Price Index (CPI),\n",
+      "a measure of the average change over time in prices paid by urban consumers for a market basket of\n",
+      "consumer goods and services, is used to track these changes.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "var webQuery = \"What is the inflation rate in the US in November 2023?\";\n",
+    "\n",
+    "var r = await kernel.RunAsync(\n",
+    "    webQuery,\n",
+    "    kernel.Functions.GetFunction(\"bing\", \"search\"),\n",
+    "    kernel.Functions.GetFunction(\"conversation\", \"SummarizeConversation\")\n",
+    ");\n",
+    "Utils.Print(r.GetValue<string>());"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 6: Test Memories"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "vscode": {
+     "languageId": "polyglot-notebook"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Has tentacles? - Elephant\n",
+      "\n"
      ]
     }
    ],
@@ -530,12 +513,110 @@
     "    limit: 1, \n",
     "    minRelevanceScore: 0.5))\n",
     "{\n",
-    "    Console.WriteLine($\"{memorySearch} - {item.Metadata.Text}\");\n",
+    "    Utils.Print($\"{memorySearch} - {item.Metadata.Text}\");\n",
     "}\n",
     "\n",
     "await kernel.Memory.RemoveAsync(db,\"1\");\n",
     "await kernel.Memory.RemoveAsync(db,\"2\");\n",
     "await kernel.Memory.RemoveAsync(db,\"3\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Alternatively, chunk and store a whole book!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "polyglot_notebook": {
+     "kernelName": "csharp"
+    },
+    "vscode": {
+     "languageId": "polyglot-notebook"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Chunks: 46\n",
+      "Chunk 0 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 1 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 2 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 3 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 4 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 5 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 6 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 7 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 8 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 9 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 10 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 11 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 12 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 13 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 14 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 15 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 16 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 17 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 18 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 19 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 20 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 21 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 22 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 23 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 24 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 25 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 26 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 27 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 28 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 29 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 30 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 31 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 32 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 33 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 34 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 35 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 36 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 37 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 38 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 39 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 40 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 41 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 42 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 43 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 44 of 46 saved to memory collection intelligent-investor\n",
+      "Chunk 45 of 46 saved to memory collection intelligent-investor\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Read file & convert it into smaller chunks\n",
+    "var chunks = await KernelHelper.GetChunksAsync(\"../../../data/intelligent-investor.txt\");\n",
+    "Console.WriteLine($\"Chunks: {chunks.Count()}\");\n",
+    "\n",
+    "var db = \"intelligent-investor\";\n",
+    "// Save chunks into memory\n",
+    "for (var i = 0; i < chunks.Count(); i++)\n",
+    "{\n",
+    "    var chunk = chunks[i];        \n",
+    "    await kernel.Memory.SaveInformationAsync(\n",
+    "        collection: db,                     // Collection where to save the information.\n",
+    "        text: chunk,                        // Information to save.\n",
+    "        id: $\"{db}-{i}\",                    // Unique identifier.\n",
+    "        description: $\"d:{db} c:{i}\",       // Optional description.\n",
+    "        additionalMetadata: i.ToString()    // Optional string for saving custom metadata.\n",
+    "    );\n",
+    "\n",
+    "    Console.WriteLine($\"Chunk {i} of {chunks.Count} saved to memory collection {db}\");\n",
+    "}"
    ]
   }
  ],


### PR DESCRIPTION
# Fix and Enhance Functionality Post Microsoft.SemanticKernel v1.0.0-beta1 Upgrade

- **Bug Fixes**:
  - Addressed breaking changes introduced in Microsoft.SemanticKernel version 1.0.0-beta1 following the upgrade. This involved changes like renaming "Skills" to "Plugins", addressing Memory Plugin extraction issues, renaming classes and methods, refactoring configurations, and updating result types among others as per the detailed breakdown provided.

- **Enhancements**:
  - Ignored config/settings.json file to prevent potential sensitive data exposure.
  - Added Organization ID configuration for OpenAI.
  - Introduced Configuration Models & Helpers for handling OpenAI, AzureOpenAI, Azure Search and Bing Search functionalities.
  - Developed a comprehensive KernelHelper for setting up OpenAI and/or AzureOpenAI capabilities within SemanticKernel (SK).
  - Expanded plugin capabilities by adding all Core Plugins, Bing Search Plugin, Memories & Plugins with special mentions to memories using Azure Search.
  - Further enriched the plugin suite by adding WebFileDownload & SearchUrlPlugin to the kernel.
  - Incorporated a ConversationSummaryPlugin along with String Helper Utilities, enhancing the ability to chunk & store memories in Azure Search.
  - Provided new sample notebooks supporting the latest SK SDK, and demonstrating the mitigation of breaking changes introduced in SK v1.0.

This substantial update not only addresses the breaking changes but also lays down the foundation for more robust and diversified capabilities within the SemanticKernel framework, setting a solid groundwork for future developments and improvements.

---

Breaking Changes Summary:

```text
The term "Skills" has been replaced with "Plugins" to avoid confusion³.
Memory Plugin extraction has been done in two parts¹.
... (rest of the breaking changes as listed)
ContextVariables have been made into a proper Dictionary¹.
```
